### PR TITLE
fwdpp: Boost is a build dependency

### DIFF
--- a/Formula/fwdpp.rb
+++ b/Formula/fwdpp.rb
@@ -17,7 +17,7 @@ class Fwdpp < Formula
   # build fails on Yosemite
   depends_on :macos => :el_capitan
 
-  depends_on "boost"
+  depends_on "boost" => :build
   depends_on "gsl"
   depends_on "libsequence"
 


### PR DESCRIPTION
```
brew linkage fwdpp
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /Users/sjackman/.homebrew/opt/libsequence/lib/libsequence.20.dylib (brewsci/bio/libsequence)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgsl.23.dylib (gsl)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgslcblas.0.dylib (gsl)
Dependencies with no linkage:
  boost
```