### PR TITLE
kmc: Does not depend on gcc and fix bottle block

### DIFF
--- a/Formula/kmc.rb
+++ b/Formula/kmc.rb
@@ -8,14 +8,14 @@ class Kmc < Formula
   revision 1
 
   bottle do
+    root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation
-    sha256 "37113f2f997dafce42289bb75710a340d0623b3b77e020235ca27c349199a343" => :sierra
+    sha256 "37113f2f997dafce42289bb75710a340d0623b3b77e020235ca27c349199a343" => :sierra_or_later
     sha256 "afd0759beef802e266f150b2f505445b6962c9a7d25493d4cd02a90319ff8e46" => :x86_64_linux
   end
 
-  fails_with :clang # fatal error: 123:10: 'ext/algorithm' file not found
-
-  depends_on "gcc" if OS.mac?
+  # Fix error: 'ext/algorithm' file not found
+  fails_with :clang
 
   needs :cxx14
 


### PR DESCRIPTION
No linkage to `gcc` and so no run time dependency.
```
❯❯❯ brew linkage kmc
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libz.1.dylib
```