### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/Formula/emboss.rb
+++ b/Formula/emboss.rb
@@ -1,5 +1,5 @@
 class Emboss < Formula
-  # cite Rice_2000: "http://doi.org/10.1016/S0168-9525(00)02024-2"
+  # cite Rice_2000: "https://doi.org/10.1016/S0168-9525(00)02024-2"
   desc "European Molecular Biology Open Software Suite"
   homepage "https://emboss.sourceforge.io/"
   url "ftp://emboss.open-bio.org/pub/EMBOSS/EMBOSS-6.6.0.tar.gz"

--- a/Formula/maker.rb
+++ b/Formula/maker.rb
@@ -1,7 +1,7 @@
 class Maker < Formula
-  # cite Cantarel_2007: "http://doi.org/10.1101/gr.6743907" # MAKER
-  # cite Holt_2011: "http://doi.org/10.1186/1471-2105-12-491" # MAKER2
-  # cite Campbell_2013: "http://doi.org/10.1104/pp.113.230144" # MAKER-P
+  # cite Cantarel_2007: "https://doi.org/10.1101/gr.6743907" # MAKER
+  # cite Holt_2011: "https://doi.org/10.1186/1471-2105-12-491" # MAKER2
+  # cite Campbell_2013: "https://doi.org/10.1104/pp.113.230144" # MAKER-P
   desc "Genome annotation pipeline"
   homepage "http://www.yandell-lab.org/software/maker.html"
   url "http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-2.31.9.tgz"

--- a/Formula/raxml.rb
+++ b/Formula/raxml.rb
@@ -1,5 +1,5 @@
 class Raxml < Formula
-  # cite Stamatakis_2014: "http://doi.org/10.1093/bioinformatics/btu033"
+  # cite Stamatakis_2014: "https://doi.org/10.1093/bioinformatics/btu033"
   desc "Maximum likelihood analysis of large phylogenies"
   homepage "https://sco.h-its.org/exelixis/web/software/raxml/index.html"
   url "https://github.com/stamatak/standard-RAxML/archive/v8.2.11.tar.gz"

--- a/Formula/squeakr.rb
+++ b/Formula/squeakr.rb
@@ -1,5 +1,5 @@
 class Squeakr < Formula
-  # cite Pandey_2017: "https://dx.doi.org/10.1093/bioinformatics/btx636"
+  # cite Pandey_2017: "https://doi.org/10.1093/bioinformatics/btx636"
   desc "Exact and Approximate k-mer Counting System"
   homepage "https://github.com/splatlab/squeakr"
   url "https://github.com/splatlab/squeakr/archive/v0.5.tar.gz"

--- a/Formula/uniqtag.rb
+++ b/Formula/uniqtag.rb
@@ -1,5 +1,5 @@
 class Uniqtag < Formula
-  # Jackman_2014: "http://dx.doi.org/10.1101/007583"
+  # Jackman_2014: "https://doi.org/10.1101/007583"
   desc "Abbreviate strings to short unique identifiers"
   homepage "https://github.com/sjackman/uniqtag"
   url "https://github.com/sjackman/uniqtag/archive/1.0.tar.gz"


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all static DOI links, as you also show [in the CONTRIBUTING.md](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md#citation).

Because I'm touching only comments, I omitted the build tests. Hope this is OK.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?