### PR TITLE
canu: Rebuild for gcc on macOS

### DIFF
--- a/Formula/canu.rb
+++ b/Formula/canu.rb
@@ -4,6 +4,7 @@ class Canu < Formula
   homepage "https://canu.readthedocs.org/en/latest/"
   url "https://github.com/marbl/canu/archive/v1.7.tar.gz"
   sha256 "c5be54b0ad20729093413e7e722a19637d32e966dc8ecd2b579ba3e4958d378a"
+  revision 1
   head "https://github.com/marbl/canu.git"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fix the error
```
canu: dyld: Library not loaded: /usr/local/opt/gcc/lib/gcc/7/libgomp.1.dylib
```
See https://github.com/brewsci/homebrew-bio/issues/283
