### PR TITLE
links-scaffolder 1.8.5

### DIFF
--- a/Formula/links-scaffolder.rb
+++ b/Formula/links-scaffolder.rb
@@ -2,10 +2,10 @@ class LinksScaffolder < Formula
   # cite Warren_2015: "https://doi.org/10.1186/s13742-015-0076-3"
   desc "Long Interval Nucleotide K-mer Scaffolder"
   homepage "http://www.bcgsc.ca/platform/bioinfo/software/links"
-  url "http://www.bcgsc.ca/platform/bioinfo/software/links/releases/1.8.4/links_v1-8-4.tar.gz"
-  version "1.8.4"
-  sha256 "9256bc26669a900fd6d8bfce07c69464ca9f45fb54ce89d145c54b732f2407a0"
-  revision 1
+  url "https://github.com/bcgsc/LINKS/releases/download/v1.8.5/links_v1-8-5.tar.gz"
+  version "1.8.5"
+  sha256 "aebd2e74d357045c28d03041f77023ba7d15fea285d50f33eef14d58e354981c"
+  head "https://github.com/bcgsc/LINKS.git"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -21,7 +21,7 @@ class LinksScaffolder < Formula
     if OS.mac?
       # Fix error: no known conversion from 'size_t' (aka 'unsigned long') to 'uint64_t &' (aka 'unsigned long long &')
       cd "lib/bloomfilter" do
-        inreplace ["BloomFilter.hpp", "RollingHash.h", "RollingHashIterator.h", "swig/BloomFilter.i"],
+        inreplace ["BloomFilter.hpp", "swig/BloomFilter.i"],
           "size_t", "uint64_t"
       end
     end


### PR DESCRIPTION
https://github.com/bcgsc/LINKS/releases/tag/v1.8.5