### PR TITLE
trnascan 1.3.1

### DIFF
--- a/Formula/trnascan.rb
+++ b/Formula/trnascan.rb
@@ -2,9 +2,9 @@ class Trnascan < Formula
   # cite Lowe_1997: "https://doi.org/10.1093/nar/25.5.0955"
   desc "Detect tRNA in genome sequence"
   homepage "http://eddylab.org/software.html"
-  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE.tar.Z"
-  version "1.23"
-  sha256 "843caf3e258a6293300513ddca7eb7dbbd2225e5baae1e5a7bcafd509f6dd550"
+  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE-#{version}.tar.gz"
+  version "1.3.1"
+  sha256 "862924d869453d1c111ba02f47d4cd86c7d6896ff5ec9e975f1858682282f316"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/trnascan.rb
+++ b/Formula/trnascan.rb
@@ -2,7 +2,7 @@ class Trnascan < Formula
   # cite Lowe_1997: "https://doi.org/10.1093/nar/25.5.0955"
   desc "Detect tRNA in genome sequence"
   homepage "http://eddylab.org/software.html"
-  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE-#{version}.tar.gz"
+  url "http://eddylab.org/software/tRNAscan-SE/tRNAscan-SE-1.3.1.tar.gz"
   version "1.3.1"
   sha256 "862924d869453d1c111ba02f47d4cd86c7d6896ff5ec9e975f1858682282f316"
 


### PR DESCRIPTION
As the version naming of trnascan, 1.3.1 is later then 1.23.
Also there is already a 2.0.0 version.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
