### PR TITLE
mummer 4.0.0beta2

### DIFF
--- a/Formula/mummer.rb
+++ b/Formula/mummer.rb
@@ -1,47 +1,17 @@
 class Mummer < Formula
-  # cite Kurtz_2004: "https://doi.org/10.1186/gb-2004-5-2-r12"
+  # cite Mar_ais_2018: "https://doi.org/10.1371/journal.pcbi.1005944"
   desc "Alignment of large-scale DNA and protein sequences"
-  homepage "https://mummer.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/mummer/mummer/3.23/MUMmer3.23.tar.gz"
-  sha256 "1efad4f7d8cee0d8eaebb320a2d63745bb3a160bb513a15ef7af46f330af662f"
-  revision 3
-
-  bottle do
-    root_url "https://linuxbrew.bintray.com/bottles-bio"
-    cellar :any_skip_relocation
-    sha256 "2642a41271e0a4d0522c3d1890d1dfc6ced4ad03aa90ba31c37210f0a96a2e41" => :sierra_or_later
-    sha256 "22df96cb1a3e421e5af2e432e3cfc10834ee13fa1e2916aae6a820dbcddcf8c5" => :x86_64_linux
-  end
-
-  depends_on "tcsh" unless OS.mac?
-
-  # Fix the error: Can't use 'defined(%hash)'
-  patch do
-    url "https://gist.githubusercontent.com/sjackman/a531ee6866e6dcd89aaec37eaa60d5f4/raw/0d3f0146f1d9154913fee0564c6468c49efdc391/mummerplot.diff"
-    sha256 "9b1a3619ec1a2f91c5141c275dd6ddcc4788dbce0835697402cd6e8d006f4c2a"
-  end
-
-  TOOLS = %w[
-    annotate combineMUMs delta-filter dnadiff exact-tandems gaps mapview mgaps
-    mummer mummerplot nucmer nucmer2xfig promer repeat-match
-    run-mummer1 run-mummer3 show-aligns show-coords show-diff show-snps show-tiling
-  ].freeze
+  homepage "https://mummer4.github.io"
+  url "https://github.com/mummer4/mummer/releases/download/v4.0.0beta2/mummer-4.0.0beta2.tar.gz"
+  sha256 "cece76e418bf9c294f348972e5b23a0230beeba7fd7d042d5584ce075ccd1b93"
 
   def install
-    prefix.install Dir["*"]
-    cd prefix do
-      system "make"
-      rm_r "src"
-    end
-    TOOLS.each { |tool| bin.install_symlink prefix/tool }
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
     mv bin/"annotate", bin/"annotate-mummer"
   end
 
   test do
-    TOOLS.each do |tool|
-      # Skip two tools that do not have a help flag
-      next if ["gaps", "nucmer2xfig"].include? tool
-      assert_match /U(sage|SAGE)/, pipe_output("#{prefix}/#{tool} -h 2>&1")
-    end
+    assert_match "4.0.0beta2", pipe_output(bin/"mummer -v")
   end
 end


### PR DESCRIPTION
- [ x ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ - ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

`brew audit` fails with 
```
brewsci/bio/mummer:
  * Stable version URLs should not contain beta
```
but considering that the new paper has been published, I think it might be worth including this new version 4 in homebrew-bio. But I would follow everyone's lead on this.
