### PR TITLE
kat: bump revision for libpython3.6

### DIFF
--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -6,6 +6,7 @@ class Kat < Formula
   homepage "https://github.com/TGAC/KAT"
   url "https://github.com/TGAC/KAT/archive/Release-2.4.1.tar.gz"
   sha256 "068bd63b022588058d2ecae817140ca67bba81a9949c754c6147175d73b32387"
+  revision 1
   head "https://github.com/TGAC/KAT.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
fixes: `Missing libraries: libpython3.6m.so.1.0`