### PR TITLE
kent-tools: fix broken mysql dependency

### DIFF
--- a/Formula/kent-tools.rb
+++ b/Formula/kent-tools.rb
@@ -13,7 +13,7 @@ class KentTools < Formula
   end
 
   depends_on "libpng"
-  depends_on "mysql@5.7"
+  depends_on "mysql"
   depends_on "openssl"
   unless OS.mac?
     depends_on "rsync"
@@ -23,7 +23,7 @@ class KentTools < Formula
 
   def install
     libpng = Formula["libpng"]
-    mysql = Formula["mysql@5.7"]
+    mysql = Formula["mysql"]
 
     args = ["userApps", "BINDIR=#{bin}", "SCRIPTS=#{bin}"]
     args << "MACHTYPE=#{`uname -m`.chomp}"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
```
Missing libraries: libmysqlclient.so.20
```
change mysql dependency to the latest mysql version 