### PR TITLE
porechop: fix python dependency

### DIFF
--- a/Formula/porechop.rb
+++ b/Formula/porechop.rb
@@ -3,6 +3,7 @@ class Porechop < Formula
   homepage "https://github.com/rrwick/Porechop"
   url "https://github.com/rrwick/Porechop/archive/v0.2.3.tar.gz"
   sha256 "bfed39f82abc54f44fffd9b13d2121868084da7ac3d158ac9b9aa6fa0257f0f4"
+  revision 1
   head "https://github.com/rrwick/Porechop"
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
```
/home/linuxbrew/.linuxbrew/opt/python/bin/python3.6: bad interpreter: No such file or directory
``` 
when I had python 3.7 installed. Porechop works with any python 3.4+ 
