### PR TITLE
nanopolish: Bump revision for hdf5

### DIFF
--- a/Formula/nanopolish.rb
+++ b/Formula/nanopolish.rb
@@ -5,6 +5,7 @@ class Nanopolish < Formula
   url "https://github.com/jts/nanopolish.git",
         :tag => "v0.9.0",
         :revision => "1c6ae110a1b7d0ca5072025b1889997fec0828ed"
+  revision 1
   head "https://github.com/jts/nanopolish.git"
 
   bottle do


### PR DESCRIPTION
Fix the error:
```
Warning! ***HDF5 library version mismatched error***
Aborted (core dumped)
```