### PR TITLE
meme: Bump revision for Perl

### DIFF
--- a/Formula/meme.rb
+++ b/Formula/meme.rb
@@ -5,7 +5,7 @@ class Meme < Formula
   url "http://meme-suite.org/meme-software/4.11.2/meme_4.11.2_2.tar.gz"
   version "4.11.2.2"
   sha256 "377238c2a9dda64e01ffae8ecdbc1492c100df9b0f84132d50c1cf2f68921b22"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
Fix the error:
```
Expat.c: loadable library and perl binaries are mismatched
(got handshake key 0xde00080, needed 0xce00080)
```