### PR TITLE
circos: Bump revision for Perl

### DIFF
--- a/Formula/circos.rb
+++ b/Formula/circos.rb
@@ -4,6 +4,7 @@ class Circos < Formula
   homepage "http://circos.ca"
   url "http://circos.ca/distribution/circos-0.69-6.tgz"
   sha256 "52d29bfd294992199f738a8d546a49754b0125319a1685a28daca71348291566"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
Fix the error:
```
Clone.c: loadable library and perl binaries are mismatched
(got handshake key 0xde00080, needed 0xce00080)
```