### PR TITLE
repeatmasker: Bump the revision for Perl

### DIFF
--- a/Formula/maker.rb
+++ b/Formula/maker.rb
@@ -6,7 +6,7 @@ class Maker < Formula
   homepage "http://www.yandell-lab.org/software/maker.html"
   url "http://yandell.topaz.genetics.utah.edu/maker_downloads/static/maker-2.31.9.tgz"
   sha256 "c92f9c8c96c6e7528d0a119224f57cf5e74fadfc5fce5f4b711d0778995cabab"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/repeatmasker.rb
+++ b/Formula/repeatmasker.rb
@@ -4,7 +4,7 @@ class Repeatmasker < Formula
   url "http://repeatmasker.org/RepeatMasker-open-4-0-7.tar.gz"
   version "4.0.7"
   sha256 "16faf40e5e2f521146f6692f09561ebef5f6a022feb17031f2ddb3e3aabcf166"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
Fix the error:
```
Soundex.c: loadable library and perl binaries are mismatched
(got handshake key 0xde00080, needed 0xce00080)
```