### PR TITLE
tbl2asn: revision for sha256 update and Linux fix

### DIFF
--- a/Formula/tbl2asn.rb
+++ b/Formula/tbl2asn.rb
@@ -37,8 +37,10 @@ class Tbl2asn < Formula
       system "patchelf",
         "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
         "--set-rpath", HOMEBREW_PREFIX/"lib",
-        "--replace-needed", "libidn.so.11", "libidn.so.12",
         bin/"tbl2asn"
+        # Normally we would use patchelf to make this change but it seems
+        # broken for this use-case. Use the Stick of Correction instead.
+        inreplace bin/"tbl2asn", "libidn.so.11", "libidn.so.12"
     end
     doc.install resource("doc")
   end

--- a/Formula/tbl2asn.rb
+++ b/Formula/tbl2asn.rb
@@ -6,11 +6,12 @@ class Tbl2asn < Formula
   version "25.6"
   if OS.mac?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/mac.tbl2asn.gz"
-    sha256 "c79416ff5fea23baf4ac10ff1a67f7f6e099980a45ac878f649821ba7b68788b"
+    sha256 "f0ef9038bb021fa0c8b546a78539fe2f34c3b22c28986c3f99d216073366ff08"
   elsif OS.linux?
     url "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz"
-    sha256 "5306321c1e9cd709c41a47a01c8193cff20bc2c71141037e739dd8b59cb30dc2"
+    sha256 "f0e7d2fc6c68b39ff7b6abb1475e0a9d63c60887cfbd2857ccf0a0923eb4b96e"
   end
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -31,13 +32,12 @@ class Tbl2asn < Formula
   end
 
   def install
-    if OS.mac?
-      bin.install "mac.tbl2asn" => "tbl2asn"
-    elsif OS.linux?
-      bin.install "linux64.tbl2asn" => "tbl2asn"
+    bin.install Dir["tbl2asn*"].first => "tbl2asn"
+    if OS.linux?
       system "patchelf",
         "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
         "--set-rpath", HOMEBREW_PREFIX/"lib",
+        "--replace-needed", "libidn.so.11", "libidn.so.12",
         bin/"tbl2asn"
     end
     doc.install resource("doc")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

* the sha256 hash changed for both Mac and Linux due to a filename change of the compressed binary
* Linux version links against `libidn.so.11` but we provide `libidn.so.12`. I tested it and it doesn't seem to break anything so `patchelf` is used to fix up the linkage.