### PR TITLE
CircleCI: Set HOMEBREW_MAKE_JOBS=4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       CIRCLE_REPOSITORY_URL: https://github.com/brewsci/homebrew-bio
       HOMEBREW_DEVELOPER: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_MAKE_JOBS: 4
     steps:
       - run: |
           cd /home/linuxbrew/.linuxbrew/Homebrew


### PR DESCRIPTION
Reduce the number of default number of make jobs to 8.

The default number of HOMEBREW_MAKE_JOBS on CircleCI for Linux is 32.
The resources available reported by CircleCI are 2 CPU and 4 GB RAM.
32 processes of GCC often exceeds the 4 GB of available memory.
Since our instance has only 2 CPU, it's likely not any faster either.