### PR TITLE
CircleCI: Remove out-of-date taps on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,8 @@ jobs:
       - run: |
           brew --version
           brew remove $(brew list)
-          brew update
-          cd $(brew --repo)
-          git fetch origin --tags
-          git reset --hard origin/master
+          rm -rf /usr/local/Homebrew/Library/Taps/
+          brew update-reset
           brew --env
           brew config
       - checkout


### PR DESCRIPTION
Updating these out-of-date taps is slow.