### PR TITLE
CircleCI: Remove --or-later

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           command: |
             mkdir /tmp/bottles
             cd /tmp/bottles
-            brew test-bot --skip-setup --or-later --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
+            brew test-bot --skip-setup --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
       - persist_to_workspace:
           root: /tmp
           paths:


### PR DESCRIPTION
Fix Error: Calling `or_later` bottles is deprecated! Use bottles
without `or_later` (or_later is implied now) instead.