### PR TITLE
xssp 3.0.5 (new formula)

### DIFF
--- a/Formula/xssp.rb
+++ b/Formula/xssp.rb
@@ -1,0 +1,35 @@
+class Xssp < Formula
+  # cite Touw_2015: "https://doi.org/10.1093/nar/gku1028"
+  desc "Create DSSP and HSSP files"
+  homepage "https://github.com/cmbi/xssp"
+  url "https://github.com/cmbi/xssp/archive/3.0.5.tar.gz"
+  sha256 "fded09f08cfb12e578e4823295dc0d0aaeff6559d5e099df23c5bcc911597ccd"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "boost"
+  depends_on "bzip2" unless OS.mac?
+
+  resource "pdb" do
+    url "https://files.rcsb.org/download/3ZZZ.pdb.gz"
+    sha256 "9c3dfd81b7bf2f991f69dd1de0df5ea16eaa6d050409b65bfbe2d1a5ad44c11a"
+  end
+
+  # This formula does not contain libzeep.
+  # If libzeep is not detected, then `mkhssp --fetch-dbrefs` is disabled.
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}",
+           "--with-boost=#{Formula["boost"].opt_prefix}"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    resource("pdb").stage do
+      system bin/"mkdssp", "-i", "3zzz.pdb", "-o", testpath/"test.dssp"
+    end
+    assert_match "POLYPYRIMIDINE", (testpath/"test.dssp").read
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
This formula is for installation of DSSP/HSSP (`mkdssp`, `mkhssp`, and so on). Recently, dssp and hssp programs have been merged into xssp packages (https://github.com/cmbi/xssp), and an issue about installation on macOS has been solved (see also, installation on OSX https://github.com/cmbi/xssp/issues/94 ).

Since brewsci/science/dssp doesn't work well now due to some drastic changes of boost libraries, I made this formula.