### PR TITLE
libsequence 1.9.6

### DIFF
--- a/Formula/libsequence.rb
+++ b/Formula/libsequence.rb
@@ -2,8 +2,8 @@ class Libsequence < Formula
   # cite Thornton_2003: "https://doi.org/10.1093/bioinformatics/btg316"
   desc "C++ library for evolutionary genetics"
   homepage "https://molpopgen.github.io/libsequence/"
-  url "https://github.com/molpopgen/libsequence/archive/1.9.2.tar.gz"
-  sha256 "e7232c969bf9dabab86cd6c592c80de521cc15287252e3a996e63d24028cdd40"
+  url "https://github.com/molpopgen/libsequence/archive/1.9.6.tar.gz"
+  sha256 "e83c4cd6924da19c22d4638a1a75fe2d11b01b66f3c68f451e93dfc697a5ef76"
   head "https://github.com/molpopgen/libsequence.git"
 
   bottle do
@@ -11,10 +11,6 @@ class Libsequence < Formula
     sha256 "008f6df3aab70d8ce22ff09a3d32ec8f516a209860288967736af1672d70283e" => :sierra
     sha256 "67a4094bd6e38d335b0100d634539f5bfbdb9814075ef651ea7a2e6559d968fd" => :x86_64_linux
   end
-
-  depends_on "boost"
-  depends_on "gsl"
-  depends_on "tbb"
 
   needs :cxx11
 


### PR DESCRIPTION
Dependencies on boost, gsl, and tbb are removed.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
