### PR TITLE
mrbayes 3.2.7a

### DIFF
--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -25,8 +25,7 @@ class Mrbayes < Formula
     system "make"
     system "make", "install"
 
-    mkdir pkgshare/"examples"
-    mv share/"examples/mrbayes", pkgshare/"examples"
+    pkgshare.install [share/"doc", share/"examples"]
   end
 
   test do

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -4,6 +4,7 @@ class Mrbayes < Formula
   homepage "https://nbisweden.github.io/MrBayes/"
   url "https://github.com/NBISweden/MrBayes/archive/v3.2.7a.tar.gz"
   sha256 "3eed2e3b1d9e46f265b6067a502a89732b6f430585d258b886e008e846ecc5c6"
+  head "https://github.com/NBISweden/MrBayes.git"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -28,10 +28,10 @@ class Mrbayes < Formula
   end
 
   test do
-    cp pkgshare/"../examples/mrbayes/finch.nex", testpath
+    cp pkgshare/"../examples/mrbayes/primates.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
     inreplace "finch.nex", "end;", cmd + "\n\nend;"
-    system bin/"mb", "finch.nex"
+    system bin/"mb", "primates.nex"
   end
 end

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -25,7 +25,7 @@ class Mrbayes < Formula
     system "make"
     system "make", "install"
 
-    pkgshare.install [share/"doc", share/"examples"]
+    doc.install share/"examples/mrbayes" => "examples"
   end
 
   test do

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -22,11 +22,9 @@ class Mrbayes < Formula
     args << "--with-mpi="  + (build.with?("open-mpi") ? "yes" : "no")
     args << "--with-readline=" + (build.with?("readline") ? "yes" : "no")
 
-    cd "src" do
-      system "./configure", *args
-      system "make"
-      bin.install "mb"
-    end
+    system "./configure", *args
+    system "make"
+    bin.install "mb"
 
     pkgshare.install ["documentation", "examples"]
   end

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -18,9 +18,9 @@ class Mrbayes < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
-    args << "--with-beagle="    + (build.with?("beagle") ? Formula["beagle"].opt_prefix : "no")
-    args << "--with-mpi="       + (build.with?("open-mpi") ? "yes" : "no")
-    args << "--with-readline="  + (build.with?("readline") ? "yes" : "no")
+    args << "--with-beagle="   + (build.with?("beagle")   ? Formula["beagle"].opt_prefix : "no")
+    args << "--with-mpi="      + (build.with?("open-mpi") ? "yes" : "no")
+    args << "--with-readline=" + (build.with?("readline") ? "yes" : "no")
 
     system "./configure", *args
     system "make"
@@ -28,7 +28,7 @@ class Mrbayes < Formula
   end
 
   test do
-    cp pkgshare/"examples/finch.nex", testpath
+    cp pkgshare/"examples/mrbayes/finch.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
     inreplace "finch.nex", "end;", cmd + "\n\nend;"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -31,7 +31,7 @@ class Mrbayes < Formula
     cp pkgshare/"../examples/mrbayes/primates.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
-    inreplace "finch.nex", "end;", cmd + "\n\nend;"
+    inreplace "primates.nex", "end;", cmd + "\n\nend;"
     system bin/"mb", "primates.nex"
   end
 end

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -19,9 +19,7 @@ class Mrbayes < Formula
 
   def install
     args = ["--prefix=#{prefix}"]
-    args << "--with-beagle="   + (build.with?("beagle")   ? Formula["beagle"].opt_prefix : "no")
-    args << "--with-mpi="      + (build.with?("open-mpi") ? "yes" : "no")
-    args << "--with-readline=" + (build.with?("readline") ? "yes" : "no")
+    args << "--with-mpi=" + (build.with?("open-mpi") ? "yes" : "no")
 
     system "./configure", *args
     system "make"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -12,15 +12,15 @@ class Mrbayes < Formula
     sha256 "de35643f5dc2c6f2234aed0d121b5446688fda285d0ecdd450a0258afc728717" => :x86_64_linux
   end
 
-  depends_on "beagle" => :recommended
-  depends_on "open-mpi" => :recommended
+  depends_on "beagle"   => :recommended
+  depends_on "open-mpi" => :optional
   depends_on "readline" => :recommended
 
   def install
     args = ["--prefix=#{prefix}"]
-    args << "--with-beagle=" + (build.with?("beagle") ? Formula["beagle"].opt_prefix : "no")
-    args << "--with-mpi="  + (build.with?("open-mpi") ? "yes" : "no")
-    args << "--with-readline=" + (build.with?("readline") ? "yes" : "no")
+    args << "--with-beagle="    + (build.with?("beagle") ? Formula["beagle"].opt_prefix : "no")
+    args << "--with-mpi="       + (build.with?("open-mpi") ? "yes" : "no")
+    args << "--with-readline="  + (build.with?("readline") ? "yes" : "no")
 
     system "./configure", *args
     system "make"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -12,7 +12,7 @@ class Mrbayes < Formula
     sha256 "de35643f5dc2c6f2234aed0d121b5446688fda285d0ecdd450a0258afc728717" => :x86_64_linux
   end
 
-  depends_on "beagle"   => :recommended
+  depends_on "beagle"
   depends_on "readline"
   depends_on "open-mpi" => :optional
 

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -24,9 +24,7 @@ class Mrbayes < Formula
 
     system "./configure", *args
     system "make"
-    bin.install "mb"
-
-    pkgshare.install ["documentation", "examples"]
+    system "make", "install"
   end
 
   test do

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -1,9 +1,9 @@
 class Mrbayes < Formula
   # cite Ronquist_2003: "https://doi.org/10.1093/bioinformatics/btg180"
   desc "Bayesian inference of phylogenies and evolutionary models"
-  homepage "https://mrbayes.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/mrbayes/mrbayes/3.2.6/mrbayes-3.2.6.tar.gz"
-  sha256 "f8fea43b5cb5e24a203a2bb233bfe9f6e7f77af48332f8df20085467cc61496d"
+  homepage "https://nbisweden.github.io/MrBayes/"
+  url "https://github.com/NBISweden/MrBayes/archive/v3.2.7a.tar.gz"
+  sha256 "efc4ee9f1c8b0ba8ebcdd904541f971b4d41b1bd0198c758830e5d10a1b67c8d"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -12,18 +12,17 @@ class Mrbayes < Formula
     sha256 "de35643f5dc2c6f2234aed0d121b5446688fda285d0ecdd450a0258afc728717" => :x86_64_linux
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "beagle" => :recommended
   depends_on "open-mpi" => :recommended
+  depends_on "readline" => :recommended
 
   def install
-    args = ["--disable-debug", "--prefix=#{prefix}"]
+    args = ["--prefix=#{prefix}"]
     args << "--with-beagle=" + (build.with?("beagle") ? Formula["beagle"].opt_prefix : "no")
-    args << "--enable-mpi="  + (build.with?("open-mpi") ? "yes" : "no")
+    args << "--with-mpi="  + (build.with?("open-mpi") ? "yes" : "no")
+    args << "--with-readline=" + (build.with?("readline") ? "yes" : "no")
 
     cd "src" do
-      system "autoconf"
       system "./configure", *args
       system "make"
       bin.install "mb"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -25,6 +25,7 @@ class Mrbayes < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
+    pkgshare.install [share/"documentation", share/"examples"]
   end
 
   test do

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -28,7 +28,7 @@ class Mrbayes < Formula
   end
 
   test do
-    cp pkgshare/"examples/mrbayes/finch.nex", testpath
+    cp pkgshare/"../examples/mrbayes/finch.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
     inreplace "finch.nex", "end;", cmd + "\n\nend;"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -26,6 +26,8 @@ class Mrbayes < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
+
+    mkdir pkgshare/"examples"
     mv share/"examples/mrbayes", pkgshare/"examples"
   end
 

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -29,7 +29,7 @@ class Mrbayes < Formula
   end
 
   test do
-    cp pkgshare/"examples/mrbayes/primates.nex", testpath
+    cp doc/"examples/primates.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
     inreplace "primates.nex", "end;", cmd + "\n\nend;"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -29,7 +29,7 @@ class Mrbayes < Formula
   end
 
   test do
-    cp pkgshare/"../examples/mrbayes/primates.nex", testpath
+    cp pkgshare/"examples/mrbayes/primates.nex", testpath
     cmd = "mcmc ngen = 50000; sump; sumt;"
     cmd = "set usebeagle=yes beagledevice=cpu;" + cmd if build.with? "beagle"
     inreplace "primates.nex", "end;", cmd + "\n\nend;"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -13,7 +13,7 @@ class Mrbayes < Formula
   end
 
   depends_on "beagle"   => :recommended
-  depends_on "readline" => :recommended
+  depends_on "readline"
   depends_on "open-mpi" => :optional
 
   def install

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -3,7 +3,7 @@ class Mrbayes < Formula
   desc "Bayesian inference of phylogenies and evolutionary models"
   homepage "https://nbisweden.github.io/MrBayes/"
   url "https://github.com/NBISweden/MrBayes/archive/v3.2.7a.tar.gz"
-  sha256 "efc4ee9f1c8b0ba8ebcdd904541f971b4d41b1bd0198c758830e5d10a1b67c8d"
+  sha256 "3eed2e3b1d9e46f265b6067a502a89732b6f430585d258b886e008e846ecc5c6"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -26,7 +26,7 @@ class Mrbayes < Formula
     system "./configure", *args
     system "make"
     system "make", "install"
-    pkgshare.install [share/"documentation", share/"examples"]
+    mv share/"examples/mrbayes", pkgshare/"examples"
   end
 
   test do

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -13,8 +13,8 @@ class Mrbayes < Formula
   end
 
   depends_on "beagle"   => :recommended
-  depends_on "open-mpi" => :optional
   depends_on "readline" => :recommended
+  depends_on "open-mpi" => :optional
 
   def install
     args = ["--prefix=#{prefix}"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?

Although, the updated formula was edited by hand.

- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

This PR updates the MrBayes (`mrbayes`) formula for Homebrew to the latest release (3.2.7a).  The updated formula was made manually from the existing old formula, so the the PR probably needs at least a pair of eyes on it to make sure I did not miss anything essential.

The updated formula

* Points to the new web page hosted at GitHub
* Pulls the latest `tar` archive off from GitHub
* Contains the correct SHA256 hash of above mentioned `tar` archive
* Does not depend on GNU auto-tools
* Recommends `readline` and `beagle` while leaving `openmpi` optional
* Builds and installs ok, as far as I can see
* Has an updated test that passes

I did not touch the `bottle` things as I'm not sure what that is.

I'm happy to make adjustments.

Regards,
