### PR TITLE
CircleCI: Unshallow Homebrew/brew repo if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - run: |
           cd /home/linuxbrew/.linuxbrew/Homebrew
-          if [ -e .git/shallow ]; then echo git fetch --unshallow; fi
+          if [ -e .git/shallow ]; then git fetch --unshallow; fi
           git fetch origin --tags
           git reset --hard origin/master
           cd /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core


### PR DESCRIPTION
The previous commit included an unintended "echo".
https://github.com/brewsci/homebrew-bio/pull/556