### PR TITLE
vcflib: bump revision for gcc

### DIFF
--- a/Formula/vcflib.rb
+++ b/Formula/vcflib.rb
@@ -3,7 +3,7 @@ class Vcflib < Formula
   homepage "https://github.com/ekg/vcflib"
   url "https://github.com/ekg/vcflib.git",
     :tag => "v1.0.0-rc2", :revision => "5b0f4d5b0cbdfb7b890353b08b9d397c92312d8f"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

```
 ❯ /usr/local/Cellar/vcflib/1.0.0_1/bin/vcfallelicprimitives -h 2>&1
dyld: Symbol not found: __ZTTNSt7__cxx1119basic_istringstreamIcSt11char_traitsIcESaIcEEE
  Referenced from: /usr/local/Cellar/vcflib/1.0.0_1/bin/vcfallelicprimitives
  Expected in: /usr/lib/libstdc++.6.dylib
 in /usr/local/Cellar/vcflib/1.0.0_1/bin/vcfallelicprimitives
[1]    78206 abort      /usr/local/Cellar/vcflib/1.0.0_1/bin/vcfallelicprimitives -h 2>&1
```