### PR TITLE
fasttree: bump revision for gcc

### DIFF
--- a/Formula/fasttree.rb
+++ b/Formula/fasttree.rb
@@ -4,6 +4,7 @@ class Fasttree < Formula
   homepage "http://microbesonline.org/fasttree/"
   url "http://microbesonline.org/fasttree/FastTree-2.1.10.c"
   sha256 "54cb89fc1728a974a59eae7a7ee6309cdd3cddda9a4c55b700a71219fc6e926d"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -21,9 +22,10 @@ class Fasttree < Formula
   option "without-openmp", "Disable multithreading support"
   option "without-sse", "Disable SSE parallel instructions"
 
-  fails_with :clang # needs OpenMP
-
-  depends_on "gcc" if OS.mac? # needs OpenMP
+  if build.with? "openmp"
+    fails_with :clang # needs OpenMP
+    depends_on "gcc" if OS.mac? # needs OpenMP
+  end
 
   def install
     opts = %w[-O3 -finline-functions -funroll-loops]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

```
 ❯ FastTree -help
dyld: Library not loaded: /usr/local/opt/gcc/lib/gcc/8/libgomp.1.dylib
  Referenced from: /usr/local/bin/FastTree
  Reason: image not found
[1]    8710 abort      FastTree -help
```