### PR TITLE
parsnp: bump revision for gcc

### DIFF
--- a/Formula/parsnp.rb
+++ b/Formula/parsnp.rb
@@ -4,7 +4,8 @@ class Parsnp < Formula
   homepage "https://github.com/marbl/parsnp"
   url "https://github.com/marbl/parsnp/archive/v1.2.tar.gz"
   sha256 "c2cbefcf961925c3368476420e28a63741376773f948094ed845a32291bda436"
-  revision 2
+  revision 3
+  head "https://github.com/marbl/parsnp.git"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -13,18 +14,22 @@ class Parsnp < Formula
     sha256 "69d7edf2c58a0ee90edd73c653090b578056a36ef0d939ad065ea0279eb7886e" => :x86_64_linux
   end
 
-  fails_with :clang # needs openmp
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
   depends_on "fasttree"
-  depends_on "gcc" if OS.mac? # needs opemmp
   depends_on "harvest-tools"
   depends_on "libmuscle"
-  depends_on "zlib" unless OS.mac?
+
+  if OS.mac?
+    depends_on "gcc"
+  else
+    depends_on "zlib"
+  end
+
+  fails_with :clang # needs openmp
 
   def install
     # remove binaries


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

```
 ❯ brew test parsnp
Testing brewsci/bio/parsnp
==> /usr/local/Cellar/parsnp/1.2_2/bin/parsnp -v 2>&1
sh: line 1: 21478 Abort trap: 6           /usr/local/Cellar/parsnp/1.2_2/bin/parsnp -v 2>&1
Error: brewsci/bio/parsnp: failed
An exception occurred within a child process:
  Test::Unit::AssertionFailedError: <0> expected but was
<134>.
```