### PR TITLE
vt: bump revision for gcc

### DIFF
--- a/Formula/vt.rb
+++ b/Formula/vt.rb
@@ -4,7 +4,7 @@ class Vt < Formula
   homepage "https://genome.sph.umich.edu/wiki/Vt"
   url "https://github.com/atks/vt/archive/0.5772.tar.gz"
   sha256 "b147520478a2f7c536524511e48133d0360e88282c7159821813738ccbda97e7"
-  revision 1
+  revision 2
   head "https://github.com/atks/vt.git"
 
   bottle do


### PR DESCRIPTION
```
 ❯ vt
dyld: Symbol not found: __ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev
  Referenced from: /usr/local/bin/vt
  Expected in: /usr/lib/libstdc++.6.dylib
 in /usr/local/bin/vt
[1]    1048 abort      vt
```