### PR TITLE
maxbin2 2.2.6

### DIFF
--- a/Formula/maxbin2.rb
+++ b/Formula/maxbin2.rb
@@ -1,9 +1,9 @@
 class Maxbin2 < Formula
   # cite Wu_2016: "https://doi.org/10.1093/bioinformatics/btv638"
   desc "Binning algorithm to recover genomes from metagenomic datasets"
-  homepage "https://downloads.jbei.org/data/microbial_communities/MaxBin/MaxBin.html"
-  url "https://downloads.sourceforge.net/project/maxbin2/MaxBin-2.2.5.tar.gz"
-  sha256 "4fb248ec5173ce93055e72d9d806f2037b4e12f10c5c643b5ba7d265bb7c1459"
+  homepage "https://sourceforge.net/projects/maxbin2/"
+  url "https://downloads.sourceforge.net/project/maxbin2/MaxBin-2.2.6.tar.gz"
+  sha256 "2fdef85a7af175c605be51dd7b410087bf2602945ca692521c06c24d0c90cd30"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -20,18 +20,23 @@ class Maxbin2 < Formula
   depends_on "hmmer"
   depends_on "idba"
   depends_on "perl" unless OS.mac?
+  depends_on "openssl"
 
   def install
     ENV.prepend_path "PERL5LIB", Formula["bioperl"].libexec/"lib/perl5"
     ENV.prepend_create_path "PERL5LIB", prefix/"perl5/lib/perl5"
     system "cpanm", "--self-contained", "-l", prefix/"perl5", "IO::Socket::SSL", "LWP::Simple"
-    cd "src" do
-      system "make"
-    end
+    system "make", "-C", "src"
     (libexec/"src").install "src/MaxBin"
     rm_r "src"
     libexec.install Dir["*"]
-    bin.env_script_all_files libexec, "PERL5LIB" => ENV["PERL5LIB"]
+    (bin/"maxbin2").write_env_script libexec/"run_MaxBin.pl", :PERL5LIB => ENV["PERL5LIB"]
+  end
+
+  def caveats; <<~EOS
+    The main executable is installed as `maxbin2`. All other executable files
+    are installed to `#{libexec}`.
+  EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Version bump and some refactoring of the previous build process. Annoyingly, the [homepage](https://github.com/gaberoo/homebrew-bio/pull/new/maxbin2-2.2.6) has a certificate error, causing `brew audit --strict --online` to fail:
```
 ❯ brew audit --strict --online maxbin2.rb
brewsci/bio/maxbin2:
  * The URL https://downloads.jbei.org/data/microbial_communities/MaxBin/MaxBin.html is not reachable
Error: 1 problem in 1 formula detected
```
This has been this way for well over a year (at least), so I don't foresee it getting fixed upstream.