### PR TITLE
flye: add correct branch name

### DIFF
--- a/Formula/flye.rb
+++ b/Formula/flye.rb
@@ -4,7 +4,7 @@ class Flye < Formula
   homepage "https://github.com/fenderglass/Flye"
   url "https://github.com/fenderglass/Flye/archive/2.4.2.tar.gz"
   sha256 "5b74d4463b860c9e1614ef655ab6f6f3a5e84a7a4d33faf3b29c7696b542c51a"
-  head "https://github.com/fenderglass/Flye.git"
+  head "https://github.com/fenderglass/Flye.git", :branch => "flye"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

When I do `brew install --HEAD flye` I get 

```
Cloning into '/home/hielke/.cache/Homebrew/flye--git'...
warning: Could not find remote branch master to clone.
fatal: Remote branch master not found in upstream origin
```

The branch name brew should be looking for is "flye". This PR solves that. 
