### PR TITLE
exonerate 2.4.0

### DIFF
--- a/Formula/exonerate.rb
+++ b/Formula/exonerate.rb
@@ -2,18 +2,13 @@ class Exonerate < Formula
   # cite Slater_2005: "https://doi.org/10.1186/1471-2105-6-31"
   desc "Pairwise sequence alignment of DNA and proteins"
   homepage "https://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate"
-  url "http://ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-2.2.0.tar.gz"
-  sha256 "0ea2720b1388fa329f889522f43029b416ae311f57b229129a65e779616fe5ff"
+  url "ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-2.4.0.tar.gz"
+  sha256 "f849261dc7c97ef1f15f222e955b0d3daf994ec13c9db7766f1ac7e77baa4042"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "da5d8b8ba78eaa5e5c9f02b6116d1a354543a69cc612e4aecd0030efaf32ddc3" => :sierra
     sha256 "ffc9dc069931c451df43d67dc0ed5b21f45594c942564eda789eac9b5002293e" => :x86_64_linux
-  end
-
-  devel do
-    url "http://ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-2.4.0.tar.gz"
-    sha256 "f849261dc7c97ef1f15f222e955b0d3daf994ec13c9db7766f1ac7e77baa4042"
   end
 
   depends_on "pkg-config" => :build
@@ -23,7 +18,7 @@ class Exonerate < Formula
     # Fix the following error. This issue is fixed upstream in 2.4.0.
     # /usr/bin/ld: socket.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
     # /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
-    inreplace "configure", 'LDFLAGS="$LDFLAGS -lpthread"', 'LIBS="$LIBS -lpthread"' unless build.devel?
+    # inreplace "configure", 'LDFLAGS="$LDFLAGS -lpthread"', 'LIBS="$LIBS -lpthread"' unless build.devel?
 
     system "./configure",
       "--disable-debug",

--- a/Formula/exonerate.rb
+++ b/Formula/exonerate.rb
@@ -15,11 +15,6 @@ class Exonerate < Formula
   depends_on "glib"
 
   def install
-    # Fix the following error. This issue is fixed upstream in 2.4.0.
-    # /usr/bin/ld: socket.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
-    # /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
-    # inreplace "configure", 'LDFLAGS="$LDFLAGS -lpthread"', 'LIBS="$LIBS -lpthread"' unless build.devel?
-
     system "./configure",
       "--disable-debug",
       "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
It seems `2.4.0` is the final version of `exonerate`. I had to comment out the line below from the code, otherwise an error would occur when trying `brew install --build-from-source exonerate`:
```
inreplace "configure", 'LDFLAGS="$LDFLAGS -lpthread"', 'LIBS="$LIBS -lpthread"' unless build.devel?
```
The error when trying to install:
```
Error: An exception occurred within a child process:
  Utils::InreplaceError: inreplace failed
configure:
  expected replacement of "LDFLAGS=\"$LDFLAGS -lpthread\"" with "LIBS=\"$LIBS -lpthread\""
```
