### PR TITLE
bowtie 1.2.3

### DIFF
--- a/Formula/bowtie.rb
+++ b/Formula/bowtie.rb
@@ -14,13 +14,13 @@ class Bowtie < Formula
   end
 
   depends_on "tbb"
+  depends_on "python@2" => :test unless OS.mac? || which("python")
 
   def install
     system "make", "install", "prefix=#{prefix}"
 
     doc.install "MANUAL", "NEWS", "TUTORIAL"
     pkgshare.install "scripts", "genomes", "indexes", "reads"
-    bin.install "bowtie-inspect"
   end
 
   test do

--- a/Formula/bowtie.rb
+++ b/Formula/bowtie.rb
@@ -20,6 +20,7 @@ class Bowtie < Formula
 
     doc.install "MANUAL", "NEWS", "TUTORIAL"
     pkgshare.install "scripts", "genomes", "indexes", "reads"
+    bin.install "bowtie-inspect"
   end
 
   test do

--- a/Formula/bowtie.rb
+++ b/Formula/bowtie.rb
@@ -2,9 +2,8 @@ class Bowtie < Formula
   # cite Langmead_2009: "https://doi.org/10.1186/gb-2009-10-3-r25"
   desc "Ultrafast memory-efficient short read aligner"
   homepage "https://bowtie-bio.sourceforge.io/"
-  url "https://github.com/BenLangmead/bowtie/archive/v1.2.2_p1.tar.gz"
-  version "1.2.2_p1"
-  sha256 "e1b02b2e77a0d44a3dd411209fa1f44f0c4ee304ef5cc83f098275085740d5a1"
+  url "https://github.com/BenLangmead/bowtie/archive/v1.2.3.tar.gz"
+  sha256 "86402114caeacbb3a3030509cb59f0b7e96361c7b3ee2dd50e2cd68200898823"
   head "https://github.com/BenLangmead/bowtie.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

`brew audit --strict bowtie` will fail. Two particular issues:
```
Stable: version 1.2.3 is redundant with version scanned from URL
```
I was able to resolve this one by removing the `version` flag in the file. 
The other problem:
```
* Non-executables were installed to "/home/dmohadjel/.linuxbrew/opt/bowtie/bin"
    The offending files are:
      /home/dmohadjel/.linuxbrew/opt/bowtie/bin/bowtie-buildc
```
