### PR TITLE
iva 1.0.9

### DIFF
--- a/Formula/iva.rb
+++ b/Formula/iva.rb
@@ -60,7 +60,7 @@ class Iva < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/iva --version 2>&1")
+    assert_match "usage", shell_output("#{bin}/iva 2>&1")
     assert_match "-f reads_fwd -r reads_rev", shell_output("#{bin}/iva --help 2>&1")
   end
 end

--- a/Formula/iva.rb
+++ b/Formula/iva.rb
@@ -2,8 +2,8 @@ class Iva < Formula
   # cite Hunt_2015: "https://doi.org/10.1093/bioinformatics/btv120"
   desc "Iterative Virus Assembler"
   homepage "https://github.com/sanger-pathogens/iva"
-  url "https://github.com/sanger-pathogens/iva/archive/v1.0.8.tar.gz"
-  sha256 "20cac9b6683a2a33dc8cf790287f0eb8c3b4d02a287a380a071d821c1e0f1040"
+  url "https://github.com/sanger-pathogens/iva/archive/v1.0.9.tar.gz"
+  sha256 "91ba402d0feacc88b3e34e71b4f10e0552702887e6e416076e57f95f6aaf7fad"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/iva.rb
+++ b/Formula/iva.rb
@@ -60,7 +60,7 @@ class Iva < Formula
   end
 
   test do
-    assert_match "usage", shell_output("#{bin}/iva 2>&1")
+    assert_match "usage", shell_output("#{bin}/iva 2>&1", 2)
     assert_match "-f reads_fwd -r reads_rev", shell_output("#{bin}/iva --help 2>&1")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

The formula is not able to install locally. When I try `brew install --build-from-source iva`, this is the error I receive:
```
==> Installing iva from brewsci/bio
==> Installing dependencies for brewsci/bio/iva: kmc, tcsh, mummer, python, numpy and smalt
==> Installing brewsci/bio/iva dependency: kmc
==> Downloading https://github.com/refresh-bio/KMC/archive/v3.1.0.tar.gz
Already downloaded: /home/dmohadjel/.cache/Homebrew/downloads/746a06b6a5875fb520c68258526ac1f7537af1b8856147fa8c654cd2f4f9e457--KMC-3.1.0.tar.gz
==> make CC=g++-5 KMC_BIN_DIR=/home/dmohadjel/.linuxbrew/Cellar/kmc/3.1.0/bin -fmakefile
Last 15 lines from /home/dmohadjel/.cache/Homebrew/Logs/kmc/01.make:
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj4EELj4ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj4EELj4ELb0EE7ProcessEv]+0x3673): undefined reference to `void RadulsSort::RadixSortMSD_SSE41<CKmer<4u> >(CKmer<4u>*, CKmer<4u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter/kmer_counter.o: in function `CKMC<CKmer<3u>, 3u, false>::Process()':
kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv]+0x19f4): undefined reference to `void RadulsSort::RadixSortMSD_SSE2<CKmer<3u> >(CKmer<3u>*, CKmer<3u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv]+0x35fd): undefined reference to `void RadulsSort::RadixSortMSD_AVX<CKmer<3u> >(CKmer<3u>*, CKmer<3u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj3EELj3ELb0EE7ProcessEv]+0x3663): undefined reference to `void RadulsSort::RadixSortMSD_SSE41<CKmer<3u> >(CKmer<3u>*, CKmer<3u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter/kmer_counter.o: in function `CKMC<CKmer<2u>, 2u, false>::Process()':
kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv]+0x1a14): undefined reference to `void RadulsSort::RadixSortMSD_SSE2<CKmer<2u> >(CKmer<2u>*, CKmer<2u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv]+0x360d): undefined reference to `void RadulsSort::RadixSortMSD_AVX<CKmer<2u> >(CKmer<2u>*, CKmer<2u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj2EELj2ELb0EE7ProcessEv]+0x3673): undefined reference to `void RadulsSort::RadixSortMSD_SSE41<CKmer<2u> >(CKmer<2u>*, CKmer<2u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter/kmer_counter.o: in function `CKMC<CKmer<1u>, 1u, false>::Process()':
kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv]+0x1a14): undefined reference to `void RadulsSort::RadixSortMSD_SSE2<CKmer<1u> >(CKmer<1u>*, CKmer<1u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv]+0x360d): undefined reference to `void RadulsSort::RadixSortMSD_AVX<CKmer<1u> >(CKmer<1u>*, CKmer<1u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
/home/dmohadjel/.linuxbrew/bin/ld: kmer_counter.cpp:(.text._ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv[_ZN4CKMCI5CKmerILj1EELj1ELb0EE7ProcessEv]+0x3673): undefined reference to `void RadulsSort::RadixSortMSD_SSE41<CKmer<1u> >(CKmer<1u>*, CKmer<1u>*, unsigned long long, unsigned int, unsigned int, CMemoryPool*)'
collect2: error: ld returned 1 exit status
make: *** [kmc] Error 1
```
