### PR TITLE
mosdepth 0.2.6

### DIFF
--- a/Formula/mosdepth.rb
+++ b/Formula/mosdepth.rb
@@ -1,8 +1,8 @@
 class Mosdepth < Formula
   desc "Fast BAM/CRAM depth calculator"
   homepage "https://github.com/brentp/mosdepth"
-  url "https://github.com/brentp/mosdepth/releases/download/v0.2.3/mosdepth"
-  sha256 "0aaeb283b296e5ee0a2d819b4842b92289145ed17a37210144f0e02edd3629c4"
+  url "https://github.com/brentp/mosdepth/releases/download/v0.2.6/mosdepth"
+  sha256 "ce936f3ad08b88d2d7b6b390528ee31c6c94d8ebf5e07ecb45f21271f86afd38"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Not able to install due to the following error:
```
==> patchelf --set-interpreter /home/linuxbrew/.linuxbrew/lib/ld.so --set-rpath /home/linuxbrew/.linuxbrew/lib /home/linuxbrew/.linuxbrew/Cellar/mosdepth/0.2.6/bin/mosdepth
patchelf: cannot find section '.interp'. The input file is most likely statically linked
```