### PR TITLE
exonerate: Change cellar to :any

### DIFF
--- a/Formula/exonerate.rb
+++ b/Formula/exonerate.rb
@@ -7,7 +7,7 @@ class Exonerate < Formula
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
-    cellar :any_skip_relocation
+    cellar :any
     sha256 "fcadadfecae574f5d9aee1b1adad4a23bd24f682bc6f76358a27512025207325" => :sierra
     sha256 "ab0093c6b90759419d20b4905100517df0eb4b8f79ec9ef68671f6aa4473a5fc" => :x86_64_linux
   end


### PR DESCRIPTION
Fix the error:
```
dyld: Library not loaded: @@HOMEBREW_PREFIX@@/opt/gettext/lib/libintl.8.dylib
  Referenced from: /usr/local/bin/exonerate
  Reason: image not found
```
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----