### PR TITLE
Upgrading GATK formula and bumping version to 4.1.3.0

### DIFF
--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -1,22 +1,45 @@
 class Gatk < Formula
   # cite McKenna_2010: "https://doi.org/10.1101/gr.107524.110"
   desc "Genome Analysis Toolkit: Variant Discovery in High-Throughput Sequencing"
-  homepage "https://software.broadinstitute.org/gatk/"
-  url "https://github.com/broadinstitute/gatk/releases/download/4.1.2.0/gatk-4.1.2.0.zip"
-  sha256 "ffc5f9b3d4b35772ee5dac3060b59dc657f30e830745160671d84d732c30dc65"
-  head "https://github.com/broadinstitute/gatk.git"
+  homepage "https://software.broadinstitute.org/gatk"
+  url "https://github.com/broadinstitute/gatk/releases/download/4.1.3.0/gatk-4.1.3.0.zip"
+  sha256 "56fd4f03b15a8a01eaa4629f62e3ab15e4d4b957c787efd2d5629b2658c3df0a"
 
   bottle :unneeded
 
-  depends_on :java
+  depends_on :java => "1.8"
   depends_on "python@2" unless OS.mac?
 
-  def install
-    prefix.install Dir["*"]
-    bin.install_symlink prefix/"gatk"
+  resource "count_reads.bam" do
+    url "https://github.com/broadinstitute/gatk/blob/626c88732c02b0fd5f395db20c91bf2784ec54b9/src/test/resources/org/broadinstitute/hellbender/tools/count_reads.bam?raw=true"
+    sha256 "656e36331a39a3641565ef7810a529ac51270b4132007d7b94e6efff99133a2c"
   end
 
+  def install
+    prefix.install "gatk"
+    prefix.install "scripts/dataproc-cluster-ui"
+    prefix.install "gatk-package-#{version}-spark.jar"
+    prefix.install "gatk-package-#{version}-local.jar"
+    bash_completion.install "gatk-completion.sh"
+    bin.install_symlink "#{prefix}/gatk"
+    bin.install_symlink "#{prefix}/dataproc-cluster-ui"
+  end
+
+  def caveats; <<~EOS
+    This brew installation does not include the necessary python dependencies to run certain gatk tools.
+    Similarly, it does not install the necessary version of R and its packages for certain plotting functions to work.
+
+    See the GATK readme for detailed installation instructions.
+       https://github.com/broadinstitute/gatk
+
+    The recommended way of running the tools with complex python dependencies is to use the pre-built docker images instead of attempting to install them locally.
+    Gatk dockers are available on docker hub:
+       https://hub.docker.com/r/broadinstitute/gatk/tags/
+  EOS
+  end
   test do
     assert_match "Usage", shell_output("#{bin}/gatk --help 2>&1")
+    testpath.install resource("count_reads.bam")
+    assert_equal "Tool returned:\n8", shell_output("#{bin}/gatk CountReads -I count_reads.bam --tmp-dir #{testpath}").strip
   end
 end


### PR DESCRIPTION
I've been maintaining my own version of a GATK formula for internal use here: https://github.com/broadinstitute/hombrew-dsp

I figured it might make sense to merge them since I think my formula has a few additional features that are nice.

* Updating the GATK formula to match broadinstitute/hombrew-dsp
* This includes some additional features:
  * Additional helper scripts are installed
  * Adds a stronger test case that actually executes a very simple tool
  * Adds a caveats section to explain that python / R dependencies for some tools are not installed as part of this.

* Update version from 4.1.2.0 -> 4.1.3.0

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
