### PR TITLE
CircleCI: Skip brew-test-bot.xml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
             brew install patchelf
             brew tap linuxbrew/xorg
             brew test-bot --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
-            mv brew-test-bot.xml brew-test-bot-linux.xml
       - persist_to_workspace:
           root: /tmp
           paths:
@@ -73,7 +72,6 @@ jobs:
             mkdir /tmp/bottles
             cd /tmp/bottles
             brew test-bot --skip-setup --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
-            mv brew-test-bot.xml brew-test-bot-macos.xml
       - persist_to_workspace:
           root: /tmp
           paths:


### PR DESCRIPTION
Work around the error:
```
mv: cannot stat 'brew-test-bot.xml': No such file or directory
```

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

See for example https://github.com/brewsci/homebrew-bio/pull/740