### PR TITLE
blat: depends on mysql not only build-time

### DIFF
--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -4,6 +4,7 @@ class Blat < Formula
   homepage "https://genome.ucsc.edu/FAQ/FAQblat.html"
   url "http://hgwdev.cse.ucsc.edu/~kent/src/blatSrc36.zip"
   sha256 "4b0fff006c86dceb7428922bfb4f8625d78fd362d205df68e4ebba04742d2c71"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"

--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -12,9 +12,9 @@ class Blat < Formula
     sha256 "97e2bc6d6fa598620ba8815c37d0cef1c106cea310a4c8e15295138e5ed88a18" => :x86_64_linux
   end
 
-  depends_on "libpng" => :build
-  depends_on "mysql" => :build
-  depends_on "openssl" => :build
+  depends_on "libpng"
+  depends_on "mysql"
+  depends_on "openssl"
 
   def install
     ENV.append_to_cflags "-I#{Formula["libpng"].opt_include}"

--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -16,6 +16,7 @@ class Blat < Formula
   depends_on "libpng"
   depends_on "mysql"
   depends_on "openssl"
+  depends_on "pkg-config" => :build
 
   def install
     ENV.append_to_cflags "-I#{Formula["libpng"].opt_include}"

--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -13,10 +13,10 @@ class Blat < Formula
     sha256 "97e2bc6d6fa598620ba8815c37d0cef1c106cea310a4c8e15295138e5ed88a18" => :x86_64_linux
   end
 
+  depends_on "pkg-config" => :build
   depends_on "libpng"
   depends_on "mysql"
   depends_on "openssl"
-  depends_on "pkg-config" => :build
 
   def install
     ENV.append_to_cflags "-I#{Formula["libpng"].opt_include}"

--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -2,7 +2,7 @@ class Blat < Formula
   # cite Kent_2002: "https://doi.org/10.1101/gr.229202"
   desc "Genomic sequence search tool"
   homepage "https://genome.ucsc.edu/FAQ/FAQblat.html"
-  url "http://hgwdev.cse.ucsc.edu/~kent/src/blatSrc36.zip"
+  url "https://hgwdev.cse.ucsc.edu/~kent/src/blatSrc36.zip"
   sha256 "4b0fff006c86dceb7428922bfb4f8625d78fd362d205df68e4ebba04742d2c71"
   revision 1
 

--- a/Formula/blat.rb
+++ b/Formula/blat.rb
@@ -13,15 +13,14 @@ class Blat < Formula
     sha256 "97e2bc6d6fa598620ba8815c37d0cef1c106cea310a4c8e15295138e5ed88a18" => :x86_64_linux
   end
 
-  depends_on "pkg-config" => :build
   depends_on "libpng"
-  depends_on "mysql"
+  depends_on "mysql@5.7"
   depends_on "openssl"
 
   def install
     ENV.append_to_cflags "-I#{Formula["libpng"].opt_include}"
     bin.mkpath
-    system "make", "MACHTYPE=#{`uname -m`.chomp}", "BINDIR=#{bin}"
+    system "make", "MYSQLLIBS='-L#{Formula["mysql@5.7"].opt_lib} -lmysqlclient'", "MACHTYPE=#{`uname -m`.chomp}", "BINDIR=#{bin}"
   end
 
   test do


### PR DESCRIPTION
Note that the current bottle doesn't work because `libmysqlclient.20.dylib` is no longer provided by `mysql`. New `libmysqlclient.21.dylib` is properly linked with `--build-from-source`.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
