### PR TITLE
links-scaffolder: revision bump for perl

### DIFF
--- a/Formula/links-scaffolder.rb
+++ b/Formula/links-scaffolder.rb
@@ -5,6 +5,7 @@ class LinksScaffolder < Formula
   url "https://github.com/bcgsc/LINKS/releases/download/v1.8.7/links_v1-8-7.tar.gz"
   version "1.8.7"
   sha256 "3401a2694a3545cb7bf3fb13a5854e5d1c5b87200cad998d967fe8e0fc980e1c"
+  revision 1
   head "https://github.com/bcgsc/LINKS.git"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?
-----

```
==> Installing links-scaffolder from brewsci/bio
==> Downloading https://linuxbrew.bintray.com/bottles-bio/links-scaffolder-1.8.7
######################################################################## 100.0%
==> Pouring links-scaffolder-1.8.7.sierra.bottle.tar.gz
Broken dependencies:
  /usr/local/opt/perl/lib/perl5/5.28.1/darwin-thread-multi-2level/CORE/libperl.dylib (perl)
Warning: links-scaffolder has broken dynamic library links:
  
Rebuild this from source with:
  brew reinstall --build-from-source links-scaffolder
If that's successful, file an issue here:
  https://github.com/brewsci/homebrew-bio/issues
```