### PR TITLE
racon: Bump revision for gcc

### DIFF
--- a/Formula/racon.rb
+++ b/Formula/racon.rb
@@ -4,7 +4,7 @@ class Racon < Formula
   homepage "https://github.com/isovic/racon"
   url "https://github.com/isovic/racon/releases/download/1.3.2/racon-v1.3.2.tar.gz"
   sha256 "7c99380a0f1091f5ee138b559e318d7e9463d3145eac026bf236751c2c4b92c7"
-  revision 1
+  revision 2
   head "https://github.com/isovic/racon.git"
 
   bottle do


### PR DESCRIPTION
Fix the error:
```
dyld: Symbol not found: __ZNKSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE4findEcm
  Referenced from: /usr/local/bin/racon
  Expected in: /usr/lib/libstdc++.6.dylib
```

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?