### PR TITLE
circle: update to latest Xcode on Mojave

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           path: /tmp/bottles
   build-macos:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.1.0"
     environment:
       CIRCLE_REPOSITORY_URL: https://github.com/brewsci/homebrew-bio
       HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
c.f. https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions