### PR TITLE
ntcard: Bump revision for gcc 9

### DIFF
--- a/Formula/ntcard.rb
+++ b/Formula/ntcard.rb
@@ -4,6 +4,7 @@ class Ntcard < Formula
   homepage "https://github.com/bcgsc/ntCard"
   url "https://github.com/bcgsc/ntCard/archive/v1.1.1.tar.gz"
   sha256 "f1b34c4d55055819908248324e6010008c43d74ab56b72ceb5a56bde4dfcdbde"
+  revision 1
   head "https://github.com/bcgsc/ntCard"
 
   bottle do


### PR DESCRIPTION
Fix the error:
```
dyld: Library not loaded: /usr/local/opt/gcc/lib/gcc/8/libgomp.1.dylib
  Referenced from: /usr/local/bin/ntcard
  Reason: image not found
```

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?