### PR TITLE
Create an alias for clustal-w (clustalw, next to clustalw2)

### DIFF
--- a/Formula/clustal-w.rb
+++ b/Formula/clustal-w.rb
@@ -20,6 +20,8 @@ class ClustalW < Formula
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+
+    bin.install_symlink "clustalw2" => "clustalw"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Some people/programs expect clustalw to found in the PATH as clustalw, even if it is version 2. Also apt will install clustalw as just clustalw. That's why I think it is a good idea to have clustalw as an alias/symlink to clustalw2 to avoid any confusion. 