### PR TITLE
wiggletools: Bump revision for htslib, fix python2

### DIFF
--- a/Formula/wiggletools.rb
+++ b/Formula/wiggletools.rb
@@ -4,6 +4,7 @@ class Wiggletools < Formula
   homepage "https://github.com/Ensembl/WiggleTools"
   url "https://github.com/Ensembl/WiggleTools/archive/v1.2.3.tar.gz"
   sha256 "2adc6c0f1738e604aa20a60b1c79ea36bc8cd030a2b6039b8e5ddc31c2bf846c"
+  revision 1
   head "https://github.com/Ensembl/WiggleTools.git"
 
   bottle do
@@ -16,11 +17,10 @@ class Wiggletools < Formula
   depends_on "gsl"
   depends_on "htslib"
   depends_on "libbigwig"
-  depends_on "python@2" => :test
-  unless OS.mac?
-    depends_on "curl"
-    depends_on "zlib"
-  end
+
+  uses_from_macos "python@2" => :test
+  uses_from_macos "curl"
+  uses_from_macos "zlib"
 
   def install
     system "make"
@@ -33,7 +33,7 @@ class Wiggletools < Formula
     cp_r pkgshare/"test", testpath
     cp_r prefix/"bin", testpath
     cd "test" do
-      system "python2", "test.py"
+      system "python2.7", "test.py"
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fix the error:
```
dyld: Library not loaded: /usr/local/opt/htslib/lib/libhts.2.dylib
  Referenced from: /private/tmp/wiggletools-test-20200220-75212-1ymmv7r/test/../bin/wiggletools
  Reason: image not found
```