### PR TITLE
Remove python@2 from gatk formula

### DIFF
--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -30,6 +30,7 @@ class Gatk < Formula
     bash_completion.install "gatk-completion.sh"
     bin.install_symlink "#{prefix}/gatk"
     bin.install_symlink "#{prefix}/dataproc-cluster-ui"
+    Language::Python.rewrite_python_shebang(Formula["python"].opt_bin/"python3")
   end
 
   def caveats

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -13,6 +13,7 @@ class Gatk < Formula
   end
 
   depends_on :java => "1.8"
+  depends_on "python"
 
   # uses_from_macos "python@2"
 

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -1,9 +1,12 @@
 class Gatk < Formula
+  include Language::Python::Shebang
+
   # cite McKenna_2010: "https://doi.org/10.1101/gr.107524.110"
   desc "Genome Analysis Toolkit: Variant Discovery in High-Throughput Sequencing"
   homepage "https://software.broadinstitute.org/gatk"
   url "https://github.com/broadinstitute/gatk/releases/download/4.1.6.0/gatk-4.1.6.0.zip"
   sha256 "1a8a0256693c0e1fb83d87b6da4bad4a182bfc2a762394650b627a882694c306"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -28,9 +31,9 @@ class Gatk < Formula
     prefix.install "gatk-package-#{version}-spark.jar"
     prefix.install "gatk-package-#{version}-local.jar"
     bash_completion.install "gatk-completion.sh"
+    bin.find { |f| rewrite_shebang detected_python_shebang, f }
     bin.install_symlink "#{prefix}/gatk"
     bin.install_symlink "#{prefix}/dataproc-cluster-ui"
-    Language::Python.rewrite_python_shebang(Formula["python"].opt_bin/"python3")
   end
 
   def caveats

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -31,7 +31,8 @@ class Gatk < Formula
     prefix.install "gatk-package-#{version}-spark.jar"
     prefix.install "gatk-package-#{version}-local.jar"
     bash_completion.install "gatk-completion.sh"
-    bin.find { |f| rewrite_shebang detected_python_shebang, f }
+    bins = ["#{prefix}/gatk","#{prefix}/dataproc-cluster-ui"]
+    bins.find { |f| rewrite_shebang detected_python_shebang, f }
     bin.install_symlink "#{prefix}/gatk"
     bin.install_symlink "#{prefix}/dataproc-cluster-ui"
   end

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -31,7 +31,7 @@ class Gatk < Formula
     prefix.install "gatk-package-#{version}-spark.jar"
     prefix.install "gatk-package-#{version}-local.jar"
     bash_completion.install "gatk-completion.sh"
-    bins = ["#{prefix}/gatk","#{prefix}/dataproc-cluster-ui"]
+    bins = ["#{prefix}/gatk", "#{prefix}/dataproc-cluster-ui"]
     bins.find { |f| rewrite_shebang detected_python_shebang, f }
     bin.install_symlink "#{prefix}/gatk"
     bin.install_symlink "#{prefix}/dataproc-cluster-ui"


### PR DESCRIPTION
Current usage of brew install brewsci/bio/gatk install (for me, on linuxbrew, not sure on mac)

```
==> Installing gatk from brewsci/bio
Error: No available formula with the name "python@2" (dependency of brewsci/bio/gatk)
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow

python@2 was deleted from homebrew/core in commit 8f8f34572d:
  python@2: delete
  Closes https://github.com/Homebrew/linuxbrew-core/issues/20091.
  Signed-off-by: Michka Popoff <michkapopoff@gmail.com>

To show the formula before removal run:
  git -C "$(brew --repo homebrew/core)" show 8f8f34572d^:Formula/python@2.rb

If you still use this formula consider creating your own tap:
  https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap

```

This change simply removes this python dependency. Basic usage of gatk does not cause me trouble and install passed after brew editing this change into the formula

- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
