### PR TITLE
upload-bottles.yml: Use pr-upload

### DIFF
--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -41,9 +41,9 @@ jobs:
           file bottles.zip
           unzip bottles.zip
           git -C "$(brew --repo ${{github.repository}})" status
-          brew test-bot --ci-upload --publish --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
           git config --global user.name "LinuxbrewTestBot"
           git config --global user.email "testbot@linuxbrew.sh"
+          brew pr-upload --bintray-org=linuxbrew --root-url=https://linuxbrew.bintray.com/bottles-bio
           cd "$(brew --repo ${{github.repository}})"
           git branch -f "pr$pr"
           git fetch origin master


### PR DESCRIPTION
Use `brew pr-upload` rather than `brew test-bot --ci-upload`.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?