### PR TITLE
wiggletools: Remove uses_from_macos "python@2"

### DIFF
--- a/Formula/wiggletools.rb
+++ b/Formula/wiggletools.rb
@@ -18,7 +18,6 @@ class Wiggletools < Formula
   depends_on "htslib"
   depends_on "libbigwig"
 
-  # uses_from_macos "python@2" => :test
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
@@ -30,10 +29,14 @@ class Wiggletools < Formula
   end
 
   test do
-    cp_r pkgshare/"test", testpath
-    cp_r prefix/"bin", testpath
-    cd "test" do
-      system "python2.7", "test.py"
+    assert_match "Command line", shell_output("#{bin}/wiggletools --help")
+
+    if which "python2.7"
+      cp_r pkgshare/"test", testpath
+      cp_r prefix/"bin", testpath
+      cd "test" do
+        system "python2.7", "test.py"
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?