### PR TITLE
Use `homebrew/ubuntu16.04:master` to fix #1027

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -16,7 +16,7 @@ jobs:
   build-linux-bottles:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/ubuntu16.04
+      image: homebrew/ubuntu16.04:master
     steps:
       - name: Update Homebrew
         run: brew update-reset

--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -8,7 +8,7 @@ jobs:
   upload-bottles:
     runs-on: ubuntu-latest
     container:
-      image: homebrew/ubuntu16.04
+      image: homebrew/ubuntu16.04:master
     env:
       HOMEBREW_BINTRAY_USER: linuxbrewtestbot
       HOMEBREW_BINTRAY_KEY: ${{secrets.HOMEBREW_BINTRAY_KEY}}


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fixes this issue:

```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
dirname: missing operand
Try 'dirname --help' for more information.
mkdir: cannot create directory '': No such file or directory
```

Fixed in Homebrew/brew#8009 (Should be included in brew version > 2.4.7)