### PR TITLE
fasttree: replace gcc dependency with libomp

### DIFF
--- a/Formula/fasttree.rb
+++ b/Formula/fasttree.rb
@@ -4,6 +4,7 @@ class Fasttree < Formula
   homepage "http://microbesonline.org/fasttree/"
   url "http://microbesonline.org/fasttree/FastTree-2.1.11.c"
   sha256 "9026ae550307374be92913d3098f8d44187d30bea07902b9dcbfb123eaa2050f"
+  revision 1
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -21,13 +22,14 @@ class Fasttree < Formula
   option "without-sse", "Disable SSE parallel instructions"
 
   if build.with? "openmp"
-    fails_with :clang # needs openmp
-    depends_on "gcc" if OS.mac? # needs openmp
+    on_macos do
+      depends_on "libomp"
+    end
   end
 
   def install
     opts = %w[-O3 -finline-functions -funroll-loops]
-    opts << "-DOPENMP" << "-fopenmp" if build.with? "openmp"
+    opts << "-DOPENMP" << "-L#{Formula["libomp"].opt_lib}" << "-lomp" if build.with? "openmp"
     opts << "-DUSE_DOUBLE" if build.with? "double"
     opts << "-DNO_SSE" if build.without? "sse"
     system ENV.cc, "-o", "FastTree", "FastTree-#{version}.c", "-lm", *opts

--- a/Formula/fasttree.rb
+++ b/Formula/fasttree.rb
@@ -28,7 +28,6 @@ class Fasttree < Formula
       -funroll-loops
       -DOPENMP
       -DUSE_DOUBLE
-      -DNO_SSE
     ]
     if OS.mac?
       opts << "-L#{Formula["libomp"].opt_lib}" << "-lomp"

--- a/Formula/fasttree.rb
+++ b/Formula/fasttree.rb
@@ -21,15 +21,20 @@ class Fasttree < Formula
   option "without-openmp", "Disable multithreading support"
   option "without-sse", "Disable SSE parallel instructions"
 
-  if build.with? "openmp"
-    on_macos do
-      depends_on "libomp"
-    end
+  on_macos do
+    depends_on "libomp" if build.with? "openmp"
   end
 
   def install
     opts = %w[-O3 -finline-functions -funroll-loops]
-    opts << "-DOPENMP" << "-L#{Formula["libomp"].opt_lib}" << "-lomp" if build.with? "openmp"
+    if build.with? "openmp"
+      opts << "-DOPENMP"
+      if OS.mac?
+        opts << "-L#{Formula["libomp"].opt_lib}" << "-lomp"
+      else
+        opts << "-fopenmp"
+      end
+    end
     opts << "-DUSE_DOUBLE" if build.with? "double"
     opts << "-DNO_SSE" if build.without? "sse"
     system ENV.cc, "-o", "FastTree", "FastTree-#{version}.c", "-lm", *opts

--- a/Formula/fasttree.rb
+++ b/Formula/fasttree.rb
@@ -17,26 +17,24 @@ class Fasttree < Formula
   # http://www.microbesonline.org/fasttree/#BranchLen
   # http://darlinglab.org/blog/2015/03/23/not-so-fast-fasttree.html
 
-  option "without-double", "Disable double precision floating point. Use single precision floating point & enable SSE"
-  option "without-openmp", "Disable multithreading support"
-  option "without-sse", "Disable SSE parallel instructions"
-
   on_macos do
-    depends_on "libomp" if build.with? "openmp"
+    depends_on "libomp"
   end
 
   def install
-    opts = %w[-O3 -finline-functions -funroll-loops]
-    if build.with? "openmp"
-      opts << "-DOPENMP"
-      if OS.mac?
-        opts << "-L#{Formula["libomp"].opt_lib}" << "-lomp"
-      else
-        opts << "-fopenmp"
-      end
+    opts = %w[
+      -O3
+      -finline-functions
+      -funroll-loops
+      -DOPENMP
+      -DUSE_DOUBLE
+      -DNO_SSE
+    ]
+    if OS.mac?
+      opts << "-L#{Formula["libomp"].opt_lib}" << "-lomp"
+    else
+      opts << "-fopenmp"
     end
-    opts << "-DUSE_DOUBLE" if build.with? "double"
-    opts << "-DNO_SSE" if build.without? "sse"
     system ENV.cc, "-o", "FastTree", "FastTree-#{version}.c", "-lm", *opts
     bin.install "FastTree"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Formulae that might need to be bumped:

- pirate
- parsnp
- nullarbor
- roary