### PR TITLE
kat: disable unsupported compiler flags on macOS

### DIFF
--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -5,7 +5,7 @@ class Kat < Formula
   url "https://github.com/TGAC/KAT/archive/Release-2.4.1.tar.gz"
   sha256 "068bd63b022588058d2ecae817140ca67bba81a9949c754c6147175d73b32387"
   license "GPL-3.0"
-  revision 2
+  revision 3
   head "https://github.com/TGAC/KAT.git"
 
   bottle do

--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -33,6 +33,14 @@ class Kat < Formula
       end
     end
 
+    inreplace [
+      "deps/boost/tools/build/src/tools/darwin.py",
+      "deps/boost/tools/build/src/tools/darwin.jam",
+    ] do |s|
+      s.gsub! "-fcoalesce-templates", ""
+      s.gsub! "-Wno-long-double", ""
+    end
+
     system "./build_boost.sh"
     system "./autogen.sh"
     system "./configure",

--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -18,7 +18,7 @@ class Kat < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  depends_on "matplotlib"
+  depends_on "brewsci/bio/matplotlib"
   depends_on "scipy"
 
   resource "tabulate" do

--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -27,18 +27,19 @@ class Kat < Formula
   end
 
   def install
-    resources.each do |r|
-      r.stage do
-        system "python3", *Language::Python.setup_install_args(libexec)
-      end
-    end
-
+    # Disable unsupported compiler flags on macOS
     inreplace [
       "deps/boost/tools/build/src/tools/darwin.py",
       "deps/boost/tools/build/src/tools/darwin.jam",
     ] do |s|
       s.gsub! "-fcoalesce-templates", ""
       s.gsub! "-Wno-long-double", ""
+    end
+
+    resources.each do |r|
+      r.stage do
+        system "python3", *Language::Python.setup_install_args(libexec)
+      end
     end
 
     system "./build_boost.sh"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Related to #1060