### PR TITLE
ghostz: replace gcc with libomp

### DIFF
--- a/Formula/ghostz.rb
+++ b/Formula/ghostz.rb
@@ -4,7 +4,7 @@ class Ghostz < Formula
   homepage "https://www.bi.cs.titech.ac.jp/ghostz/"
   url "https://www.bi.cs.titech.ac.jp/ghostz/releases/ghostz-1.0.2.tar.gz"
   sha256 "3e896563ab49ef620babfb7de7022d678dee2413d34b780d295eff8b984b9902"
-  revision 1
+  revision 2
 
   bottle do
     cellar :any_skip_relocation
@@ -13,9 +13,9 @@ class Ghostz < Formula
     sha256 "ce5f132a6ed9a711bffae6648b18f701f55d965e611ef7320847aee24061a19e" => :x86_64_linux
   end
 
-  depends_on "gcc" # needs openmp
-
-  fails_with :clang # needs openmp
+  on_macos do
+    depends_on "libomp"
+  end
 
   def install
     system "make"

--- a/Formula/ghostz.rb
+++ b/Formula/ghostz.rb
@@ -19,10 +19,16 @@ class Ghostz < Formula
 
   def install
     if OS.mac?
-      ENV.cxx11
       inreplace "Makefile",
                 "-fopenmp",
                 "-L#{Formula["libomp"].opt_lib} -lomp"
+
+      # Fix error: use of overloaded operator '==' is ambiguous (with operand
+      #            types 'std::shared_ptr<SeqmentType>' and 'long')
+      inreplace "ext/seg/src/seg.cpp",
+                "temp->next == NULL",
+                "temp->next == nullptr"
+
       inreplace Dir["**/*.{cpp,h}"] do |s|
         s.gsub! "#include <tr1/",
                 "#include <",

--- a/Formula/ghostz.rb
+++ b/Formula/ghostz.rb
@@ -18,6 +18,20 @@ class Ghostz < Formula
   end
 
   def install
+    if OS.mac?
+      ENV.cxx11
+      inreplace "Makefile",
+                "-fopenmp",
+                "-L#{Formula["libomp"].opt_lib} -lomp"
+      inreplace Dir["**/*.{cpp,h}"] do |s|
+        s.gsub! "#include <tr1/",
+                "#include <",
+                false
+        s.gsub! "std::tr1::",
+                "std::",
+                false
+      end
+    end
     system "make"
     bin.install "ghostz"
     pkgshare.install Dir["test/*.fa"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

`libomp` might be required for Linux too; I'm not sure