### PR TITLE
dsh-bio: Use depends_on openjdk instead of java 1.8+

### DIFF
--- a/Formula/dsh-bio.rb
+++ b/Formula/dsh-bio.rb
@@ -12,7 +12,7 @@ class DshBio < Formula
     sha256 "b88996865d3bca29dcea9362021862a8487adb0869bced1a82164150d952992a" => :x86_64_linux
   end
 
-  depends_on java: "1.8+"
+  depends_on "openjdk"
 
   def install
     rm Dir["bin/*.bat"] # Remove all windows files


### PR DESCRIPTION
See #1158 

- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
