### PR TITLE
nextflow: Use depends_on openjdk instead of java 1.8+

### DIFF
--- a/Formula/nextflow.rb
+++ b/Formula/nextflow.rb
@@ -14,7 +14,7 @@ class Nextflow < Formula
     sha256 "88f2bab19c5a735bfc714f64c9bcbd6293d2883713b4dee8ea5b171d6be5bcef" => :x86_64_linux
   end
 
-  depends_on java: "1.8"
+  depends_on "openjdk"
 
   def install
     bin.install "nextflow"


### PR DESCRIPTION
See #1158 

- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
