### PR TITLE
seqan3 3.0.2

### DIFF
--- a/Formula/seqan@3.rb
+++ b/Formula/seqan@3.rb
@@ -3,8 +3,8 @@ class SeqanAT3 < Formula
   # cite Reinert_2017: "https://doi.org/10.1016/j.jbiotec.2017.07.017"
   desc "Modern C++ library for sequence analysis"
   homepage "https://www.seqan.de"
-  url "https://github.com/seqan/seqan3/archive/3.0.1.tar.gz"
-  sha256 "fcf481c7989c2438857ac58eaac3a5c21447c3936bbaf9b2f9f20847da50258b"
+  url "https://github.com/seqan/seqan3/releases/download/3.0.2/seqan3-3.0.2-Source.tar.xz"
+  sha256 "bab1a9cd0c01fd486842e0fa7a5b41c1bf6d2c43fdadf4c543956923deb62ee9"
   head "https://github.com/seqan/seqan3.git"
 
   bottle do
@@ -15,15 +15,23 @@ class SeqanAT3 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "doxygen" => :build
   depends_on "xz" => :build
+  depends_on "gcc@9"
+
+  # requires c++17 and concepts
+  fails_with :clang do
+    cause "seqan3 requires concepts and c++17 support"
+  end
+
+  fails_with gcc: "4.9" # requires C++17
+  fails_with gcc: "5" # requires C++17
+  fails_with gcc: "6" # requires C++17
 
   def install
-    system "cmake", "test/documentation/"
-    system "make", "doc_usr"
-
-    include.install "include/seqan3"
-    doc.install Dir["#{buildpath}/doc_usr/html/*"]
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

--- 

~The last point gave me some issues that I couldn't fix immediately. I would appreciate any help with this:~
<details><summary>CLICK ME</summary>
<p>
```
/u/l/H/L/T/brewsci (master|✔) $ brew audit --strict seqan@3
Fetching gem metadata from https://rubygems.org/.........
Fetching thread_safe 0.3.6
Fetching concurrent-ruby 1.1.7
Fetching minitest 5.14.2
Installing minitest 5.14.2
Installing thread_safe 0.3.6
Installing concurrent-ruby 1.1.7
Fetching zeitwerk 2.4.0
Fetching ast 2.4.1
Installing zeitwerk 2.4.0
Fetching bindata 2.4.8
Installing ast 2.4.1
Using bundler 1.17.3
Fetching byebug 11.1.3
Installing bindata 2.4.8
Fetching json 2.3.1
Installing byebug 11.1.3 with native extensions
Fetching docile 1.3.2
Installing json 2.3.1 with native extensions
Installing docile 1.3.2
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching coderay 1.1.3
Fetching colorize 0.8.1
Installing coderay 1.1.3
Installing colorize 0.8.1
Fetching highline 2.0.3
Fetching connection_pool 2.2.3
Installing connection_pool 2.2.3
Installing highline 2.0.3
Fetching diff-lcs 1.4.4
Fetching unf_ext 0.0.7.7
Fetching hpricot 0.8.6
Installing diff-lcs 1.4.4
Fetching mime-types-data 3.2020.0512
Installing unf_ext 0.0.7.7 with native extensions
Installing hpricot 0.8.6 with native extensions
Installing mime-types-data 3.2020.0512
Fetching net-http-digest_auth 1.4.1
Fetching mini_portile2 2.4.0
Installing net-http-digest_auth 1.4.1
Fetching ntlm-http 0.1.1
Installing mini_portile2 2.4.0
Fetching webrobots 0.1.2
Fetching method_source 1.0.0
Installing ntlm-http 0.1.1
Fetching mustache 1.1.1
Installing method_source 1.0.0
Installing webrobots 0.1.2
Fetching parallel 1.19.2
Fetching rainbow 3.0.0
Installing mustache 1.1.1
Installing parallel 1.19.2
Fetching sorbet-runtime 0.5.5943
Installing rainbow 3.0.0
Fetching plist 3.5.0
Fetching rdiscount 2.2.0.2
Installing sorbet-runtime 0.5.5943
Installing plist 3.5.0
Fetching regexp_parser 1.8.2
Installing rdiscount 2.2.0.2 with native extensions
Installing regexp_parser 1.8.2
Fetching rexml 3.2.4
Fetching rspec-support 3.9.3
Installing rexml 3.2.4
Fetching ruby-progressbar 1.10.1
Installing rspec-support 3.9.3
Fetching unicode-display_width 1.7.0
Installing ruby-progressbar 1.10.1
Fetching ruby-macho 2.3.0
Fetching sorbet-static 0.5.5943 (universal-darwin-19)
Installing unicode-display_width 1.7.0
Fetching sorbet-runtime-stub 0.2.0
Installing ruby-macho 2.3.0
Fetching thor 1.0.1
Installing sorbet-runtime-stub 0.2.0
Fetching tzinfo 1.2.7
Installing thor 1.0.1
Fetching parser 2.7.2.0
Installing tzinfo 1.2.7
Fetching i18n 1.8.5
Installing parser 2.7.2.0
Installing i18n 1.8.5
Installing sorbet-static 0.5.5943 (universal-darwin-19)
Fetching elftools 1.1.3
Fetching simplecov 0.19.0
Installing elftools 1.1.3
Fetching net-http-persistent 4.0.0
Installing simplecov 0.19.0
Installing net-http-persistent 4.0.0
Fetching commander 4.5.2
Fetching mime-types 3.3.1
Fetching nokogiri 1.10.10
Installing commander 4.5.2
Installing mime-types 3.3.1
Fetching pry 0.13.1
Fetching parallel_tests 3.3.0
Installing parallel_tests 3.3.0
Installing pry 0.13.1
Fetching rspec-core 3.9.3
Fetching rspec-expectations 3.9.2
Installing rspec-core 3.9.3
Installing rspec-expectations 3.9.2
Installing nokogiri 1.10.10 with native extensions
Fetching rspec-mocks 3.9.1
Fetching activesupport 6.0.3.4
Installing rspec-mocks 3.9.1
Fetching rubocop-ast 0.8.0
Installing activesupport 6.0.3.4
Installing rubocop-ast 0.8.0
Fetching patchelf 1.3.0
Installing patchelf 1.3.0
Fetching sorbet 0.5.5943
Fetching parlour 4.0.1
Fetching rspec-its 1.3.0
Installing sorbet 0.5.5943
Installing parlour 4.0.1
Fetching rspec-retry 0.6.2
Installing rspec-its 1.3.0
Fetching rspec 3.9.0
Fetching rubocop 0.93.1
Installing rspec-retry 0.6.2
Installing rspec 3.9.0
Installing rubocop 0.93.1
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/byebug-11.1.3/ext/byebug
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-1bcq7f1.rb extconf.rb
creating Makefile

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/byebug-11.1.3/ext/byebug
make "DESTDIR=" clean

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/byebug-11.1.3/ext/byebug
make "DESTDIR="
make: *** No rule to make target
`/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin19/ruby/config.h',
needed by `breakpoint.o'.  Stop.

make failed, exit code 2

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/byebug-11.1.3 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/byebug-11.1.3/gem_make.out

An error occurred while installing byebug (11.1.3), and Bundler cannot continue.
Make sure that `gem install byebug -v '11.1.3' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  byebug


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/json-2.3.1/ext/json/ext/generator
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-np8ifm.rb extconf.rb
creating Makefile

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/json-2.3.1/ext/json/ext/generator
make "DESTDIR=" clean

current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/json-2.3.1/ext/json/ext/generator
make "DESTDIR="
compiling generator.c
In file included from generator.c:1:
In file included from ./../fbuffer/fbuffer.h:5:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby.h:33:
/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h:24:10: fatal error:
'ruby/config.h' file not found
#include "ruby/config.h"
         ^~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h:24:10: note: did not find
header 'config.h' in framework 'ruby' (loaded from '/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks')
1 error generated.
make: *** [generator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/json-2.3.1 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/json-2.3.1/gem_make.out

An error occurred while installing json (2.3.1), and Bundler cannot continue.
Make sure that `gem install json -v '2.3.1' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  codecov was resolved to 0.2.12, which depends on
    json


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/unf_ext-0.0.7.7/ext/unf_ext
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-y68rg5.rb extconf.rb
checking for -lstdc++... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/$(RUBY_BASE_NAME)
	--with-static-libstdc++
	--without-static-libstdc++
	--with-stdc++lib
	--without-stdc++lib
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:467:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:546:in `block in try_link0'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:543:in `try_link0'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:570:in `try_link'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:789:in `try_func'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1016:in `block in have_library'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:959:in `block in checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block (2 levels) in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:357:in `postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:958:in `checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1011:in `have_library'
	from extconf.rb:6:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/unf_ext-0.0.7.7/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/unf_ext-0.0.7.7 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/unf_ext-0.0.7.7/gem_make.out

An error occurred while installing unf_ext (0.0.7.7), and Bundler cannot continue.
Make sure that `gem install unf_ext -v '0.0.7.7' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  mechanize was resolved to 2.7.6, which depends on
    http-cookie was resolved to 1.0.3, which depends on
      domain_name was resolved to 0.5.20190701, which depends on
        unf was resolved to 0.1.4, which depends on
          unf_ext


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/hpricot-0.8.6/ext/fast_xs
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-nvq07j.rb extconf.rb
checking for stdio.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/$(RUBY_BASE_NAME)
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:467:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:585:in `block in try_compile'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:534:in `with_werror'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:585:in `try_compile'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1109:in `block in have_header'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:959:in `block in checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block (2 levels) in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:357:in `postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:958:in `checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1108:in `have_header'
	from extconf.rb:2:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/hpricot-0.8.6/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/hpricot-0.8.6 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/hpricot-0.8.6/gem_make.out

An error occurred while installing hpricot (0.8.6), and Bundler cannot continue.
Make sure that `gem install hpricot -v '0.8.6' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  ronn was resolved to 0.7.3, which depends on
    hpricot


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/nokogiri-1.10.10/ext/nokogiri
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-7qtlu8.rb extconf.rb
checking if the C compiler accepts  -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/$(RUBY_BASE_NAME)
	--help
	--clean
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:467:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:585:in `block in try_compile'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:532:in `with_werror'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:585:in `try_compile'
	from extconf.rb:138:in `nokogiri_try_compile'
	from extconf.rb:162:in `block in add_cflags'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:643:in `with_cflags'
	from extconf.rb:161:in `add_cflags'
	from extconf.rb:416:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/nokogiri-1.10.10/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/nokogiri-1.10.10 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/nokogiri-1.10.10/gem_make.out

An error occurred while installing nokogiri (1.10.10), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.10.10' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  mechanize was resolved to 2.7.6, which depends on
    nokogiri


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/rdiscount-2.2.0.2/ext
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby -I /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0 -r
./siteconf20201014-90727-tsq7z9.rb extconf.rb
checking for random()... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/$(RUBY_BASE_NAME)
	--with-rdiscount-dir
	--without-rdiscount-dir
	--with-rdiscount-include
	--without-rdiscount-include=${rdiscount-dir}/include
	--with-rdiscount-lib
	--without-rdiscount-lib=${rdiscount-dir}/lib
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:467:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:546:in `block in try_link0'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:543:in `try_link0'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:570:in `try_link'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:782:in `try_func'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1069:in `block in have_func'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:959:in `block in checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block (2 levels) in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:361:in `block in postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:331:in `open'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:357:in `postpone'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:958:in `checking_for'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mkmf.rb:1068:in `have_func'
	from extconf.rb:5:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/rdiscount-2.2.0.2/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/rdiscount-2.2.0.2 for inspection.
Results logged to /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/extensions/universal-darwin-19/2.6.0/rdiscount-2.2.0.2/gem_make.out

An error occurred while installing rdiscount (2.2.0.2), and Bundler cannot continue.
Make sure that `gem install rdiscount -v '2.2.0.2' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  ronn was resolved to 0.7.3, which depends on
    rdiscount
Error: failed to run `/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/bundle install`!
```

Installing the gems did work manually did work though.
</p>
</details>
