### PR TITLE
hssp 3.1.5 (new formula)

### DIFF
--- a/Formula/hssp.rb
+++ b/Formula/hssp.rb
@@ -1,0 +1,28 @@
+class Hssp < Formula
+  # cite Touw_2015: "https://doi.org/10.1093/nar/gku1028"
+  desc "Create HSSP file"
+  homepage "https://github.com/cmbi/xssp"
+  url "https://github.com/cmbi/hssp/archive/3.1.5.tar.gz"
+  sha256 "9462608ce6b5b92f13a3a8d94b780d85a3cac68ab38449116193754cc22dc5d0"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "boost"
+
+  uses_from_macos "bzip2"
+
+  # This formula does not contain libzeep.
+  # If libzeep is not detected, then `mkhssp --fetch-dbrefs` is disabled.
+  def install
+    system "./autogen.sh"
+    system "./configure", "--prefix=#{prefix}",
+           "--with-boost=#{Formula["boost"].opt_prefix}"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "mkhssp version", shell_output("#{bin}/mkhssp --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?
-----

This is a new formula of hssp. 
I also suggest that `xssp.rb` formula should be deprecated because two programs `mkdssp` and `mkhssp` installed by `brew install xssp` are now managed independently.