### PR TITLE
dsh-bio 1.4

### DIFF
--- a/Formula/dsh-bio.rb
+++ b/Formula/dsh-bio.rb
@@ -1,9 +1,9 @@
 class DshBio < Formula
-  desc "Tools for BED, FASTA, FASTQ, GFA1/2, GFF3, SAM, and VCF files"
+  desc "Tools for BED, FASTA, FASTQ, GAF, GFA1/2, GFF3, PAF, SAM, and VCF files"
   homepage "https://github.com/heuermh/dishevelled-bio"
-  url "https://search.maven.org/remotecontent?filepath=org/dishevelled/dsh-bio-tools/1.3.4/dsh-bio-tools-1.3.4-bin.tar.gz"
-  sha256 "afe12e1efb15a7b391628db8622817da3a39ac60291905707c7d97b3e707962d"
-  license "LGPL-3.0"
+  url "https://search.maven.org/remotecontent?filepath=org/dishevelled/dsh-bio-tools/1.4/dsh-bio-tools-1.4-bin.tar.gz"
+  sha256 "5ae307725cb3de630d45b656eccce0fc9ef2a33e57db42b184a371d578e7106c"
+  license "LGPL-3.0-or-later"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Sorry, `brew bump-formula-pr`  didn't work for this update
```
$ brew bump-formula-pr --strict dsh-bio --url= ...
...
brewsci/bio/dsh-bio:
  * Formula dsh-bio contains deprecated SPDX licenses: ["LGPL-3.0"].
    You may need to add `-only` or `-or-later` for GNU licenses (e.g. `GPL`, `LGPL`, `AGPL`, `GFDL`).
    For a list of valid licenses check: https://spdx.org/licenses/
Error: 1 problem in 1 formula detected
Error: `brew audit` failed!
```

`brew audit` on its own also fails for me, though apparently not because of this formula
```
$ brew audit --strict Formula/dsh-bio.rb
Error: undefined method `audit_exceptions' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:183:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:172:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:172:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

Note separately #1160 may still be an issue; I fixed it by installing Oracle JDK 1.8 manually, which doesn't seem like a reasonable workaround for everyone.