### PR TITLE
xssp: move `deprecate!` to after `bottle`

### DIFF
--- a/Formula/xssp.rb
+++ b/Formula/xssp.rb
@@ -5,14 +5,14 @@ class Xssp < Formula
   url "https://github.com/cmbi/xssp/releases/download/3.0.10/xssp-3.0.10.tar.gz"
   sha256 "b475d6fa62098df0e54c8dbdaa0b32de93bf5a393335f73f9b5a7e95f3090d2a"
 
-  deprecate! because: "has been replaced by brewsci/bio/dssp and brewsci/bio/hssp"
-
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any
     sha256 "da26ad34a5cb1fdff5cb02392d988b64e9141739e143567faa340eda2224e0c1" => :catalina
     sha256 "e5c633a52565607cedbbe1d0d14255ecdc56deeb4401b6a7ea823baf09639006" => :x86_64_linux
   end
+
+  deprecate! because: "has been replaced by brewsci/bio/dssp and brewsci/bio/hssp"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fixes style error:

```
xssp.rb:10:3: C: bottle (line 10) should be put before deprecate! (line 8)
```