### PR TITLE
Depend on openjdk rather than :java

### DIFF
--- a/Formula/abyss-explorer.rb
+++ b/Formula/abyss-explorer.rb
@@ -14,14 +14,14 @@ class AbyssExplorer < Formula
     sha256 "4e1f8ad29d192da909ac2ec6ea32eb7644e2dd9107e166c29aeef5a7d7f0fcdd" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     libexec.install "ABySS-explorer.jar", "lib"
     (bin / "abyss-explorer").write <<~EOS
       #!/bin/sh
       set -eu
-      exec java -jar #{libexec}/ABySS-explorer.jar "$@"
+      exec #{Formula["openjdk"]/bin}/java -jar #{libexec}/ABySS-explorer.jar "$@"
     EOS
   end
 

--- a/Formula/artemis.rb
+++ b/Formula/artemis.rb
@@ -13,7 +13,7 @@ class Artemis < Formula
     sha256 "87d973ba74d1738917f1c99acd608a1bd617e2d5c888d6ebc4067ec22dcb646d" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "artemis-v#{version}.jar"

--- a/Formula/astral.rb
+++ b/Formula/astral.rb
@@ -14,7 +14,7 @@ class Astral < Formula
     sha256 "0e0f15952cbf659a6a6654c5f11fbc4fe96d74f6c3c6843baba33d89073eacca" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     inreplace "make.sh" do |s|

--- a/Formula/bazam.rb
+++ b/Formula/bazam.rb
@@ -13,7 +13,7 @@ class Bazam < Formula
     sha256 "08d9d9e0560074dafa59cc6347fa714d717bdefe69cf90f88ce017ead1344919" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "bazam.jar"

--- a/Formula/bbtools.rb
+++ b/Formula/bbtools.rb
@@ -11,7 +11,7 @@ class Bbtools < Formula
     sha256 "1e0f94031afe0957c5db853a8fe7914facf0c93bbe0127d55f4ab8bcf906f548" => :x86_64_linux
   end
 
-  depends_on java: "1.7+"
+  depends_on "openjdk"
 
   def install
     if OS.mac?

--- a/Formula/beast2.rb
+++ b/Formula/beast2.rb
@@ -14,7 +14,7 @@ class Beast2 < Formula
   end
 
   depends_on "ant" => :build
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     # Homebrew renames the unpacked source folder, but build.xml

--- a/Formula/cluster-picker.rb
+++ b/Formula/cluster-picker.rb
@@ -13,7 +13,7 @@ class ClusterPicker < Formula
     sha256 "db273226399a88119c8790292b7262fe933012b58620dabe53868348f9fee34d" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = Dir["*.jar"].first

--- a/Formula/dsh-bio.rb
+++ b/Formula/dsh-bio.rb
@@ -12,7 +12,7 @@ class DshBio < Formula
     sha256 "b88996865d3bca29dcea9362021862a8487adb0869bced1a82164150d952992a" => :x86_64_linux
   end
 
-  depends_on java: "1.8+"
+  depends_on "openjdk"
 
   def install
     rm Dir["bin/*.bat"] # Remove all windows files

--- a/Formula/figtree.rb
+++ b/Formula/figtree.rb
@@ -11,7 +11,7 @@ class Figtree < Formula
     sha256 "0dfa41c23b48cef3c43359faa55552ccc927f68fbcaf3749168c6de4c64c1c76" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     prefix.install "lib/figtree.jar", "images"

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -15,7 +15,7 @@ class Gatk < Formula
     sha256 "e623b8e92370031f256c19b11a22b240e56f02633cf45c1e847184c451df818c" => :x86_64_linux
   end
 
-  depends_on java: "1.8"
+  depends_on "openjdk"
   depends_on "python@3.8"
 
   resource "count_reads.bam" do

--- a/Formula/gepard.rb
+++ b/Formula/gepard.rb
@@ -1,10 +1,10 @@
 class Gepard < Formula
+  # cite Krumsiek_2007: "https://doi.org/10.1093/bioinformatics/btm039"
   desc "Genome Pair Rapid Dotter"
   homepage "http://cube.univie.ac.at/gepard"
   url "https://github.com/univieCUBE/gepard/blob/master/dist/Gepard-1.40.jar?raw=true"
   sha256 "9f35adefbc4843eb87e545bb54a47ef007ea02d145f2c13df86756e63bef8418"
   license "MIT"
-  # cite Krumsiek_2007: "https://doi.org/10.1093/bioinformatics/btm039"
 
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
@@ -12,7 +12,7 @@ class Gepard < Formula
     sha256 "c8e3c9921c645c8c1656980a39168078a369dfbe7b56cc77f74fdd3741eca7d4" => :sierra
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "Gepard-#{version}.jar"

--- a/Formula/jspecies.rb
+++ b/Formula/jspecies.rb
@@ -13,7 +13,7 @@ class Jspecies < Formula
 
   depends_on "brewsci/bio/blast-legacy"
   depends_on "brewsci/bio/mummer"
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "jspecies#{version}.jar"

--- a/Formula/mhap.rb
+++ b/Formula/mhap.rb
@@ -14,7 +14,7 @@ class Mhap < Formula
     sha256 "17714c9a0a868298fe64d13cae37640ecae28323e9fc748c5696af93326a8e35" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "mhap-#{version}.jar"

--- a/Formula/minced.rb
+++ b/Formula/minced.rb
@@ -12,7 +12,7 @@ class Minced < Formula
     sha256 "834a142ba163149ba2436f3a5991c9b06b4c21b06a0f1b438b40d31f5910cc6a" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     system "make"

--- a/Formula/nextflow.rb
+++ b/Formula/nextflow.rb
@@ -14,7 +14,7 @@ class Nextflow < Formula
     sha256 "88f2bab19c5a735bfc714f64c9bcbd6293d2883713b4dee8ea5b171d6be5bcef" => :x86_64_linux
   end
 
-  depends_on java: "1.8"
+  depends_on "openjdk"
 
   def install
     bin.install "nextflow"

--- a/Formula/pathvisio.rb
+++ b/Formula/pathvisio.rb
@@ -5,9 +5,7 @@ class Pathvisio < Formula
   url "https://www.pathvisio.org/data/releases/3.3.0/pathvisio_bin-3.3.0.zip"
   sha256 "403b10e185061799225e1bf04998827edf87c442f2f872811d306997d8ecf672"
 
-  bottle :unneeded
-
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     libexec.install "LICENSE-2.0.txt", "NOTICE.txt", "pathvisio.jar", "pathvisio.sh"

--- a/Formula/pilon.rb
+++ b/Formula/pilon.rb
@@ -13,7 +13,7 @@ class Pilon < Formula
     sha256 "37157f6eb70104f6d4cd972c995db5004988295f349126f6208ce584345ff6ba" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     opts = "-Xmx1000m -Xms20m"

--- a/Formula/realphy.rb
+++ b/Formula/realphy.rb
@@ -14,7 +14,7 @@ class Realphy < Formula
     sha256 "4598375bc8dc2a4d6b7cde0a99ef0292697aae147687cfd4306de922b1fefc98" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "RealPhy_v112.jar"

--- a/Formula/rtg-tools.rb
+++ b/Formula/rtg-tools.rb
@@ -13,7 +13,7 @@ class RtgTools < Formula
     sha256 "ce63fdebf09a933feb1bb707d150eab6d929337353de6cf543ca1eae7f8926e7" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     # avoid question about sending stats back to base

--- a/Formula/sepp.rb
+++ b/Formula/sepp.rb
@@ -14,7 +14,7 @@ class Sepp < Formula
     sha256 "b81115b45f3c8075931cbf0fefef35a9357f1ff8878353c6a2f45ad8bb7234db" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
   depends_on "python"
 
   resource "DendroPy" do

--- a/Formula/snpeff.rb
+++ b/Formula/snpeff.rb
@@ -13,7 +13,7 @@ class Snpeff < Formula
     sha256 "e3088b0a1dcd51a33e74867cdb157a3bfa470101fbd71c61e3f8e00c04118dd5" => :x86_64_linux
   end
 
-  depends_on java: "1.8+"
+  depends_on "openjdk"
 
   def install
     # snpEff and SnpSift

--- a/Formula/trimmomatic.rb
+++ b/Formula/trimmomatic.rb
@@ -13,7 +13,7 @@ class Trimmomatic < Formula
     sha256 "a8ef297af91bf7e1ccb35092d054e9aefb2d2cb811a53b53756667a89756a61b" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     cmd = "trimmomatic"

--- a/Formula/trinity.rb
+++ b/Formula/trinity.rb
@@ -22,7 +22,7 @@ class Trinity < Formula
   depends_on "brewsci/bio/salmon"
   depends_on "brewsci/bio/trimmomatic"
   depends_on "htslib"
-  depends_on java: "1.8+"
+  depends_on "openjdk"
   depends_on "samtools"
 
   uses_from_macos "zlib"

--- a/Formula/varscan.rb
+++ b/Formula/varscan.rb
@@ -5,9 +5,7 @@ class Varscan < Formula
   url "https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.3.jar"
   sha256 "dc0e908ebe6a429fdd2d0f80f26c428cfc71f65429dc1816d41230b649168ff3"
 
-  bottle :unneeded
-
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "VarScan.v#{version}.jar"

--- a/Formula/varsim.rb
+++ b/Formula/varsim.rb
@@ -12,7 +12,7 @@ class Varsim < Formula
     sha256 "b06e5eb42eda0e79c90354a8f7b5768c920c4c45a72a457b732f64e12d037e39" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     jar = "VarSim.jar"

--- a/Formula/webin-cli.rb
+++ b/Formula/webin-cli.rb
@@ -12,7 +12,7 @@ class WebinCli < Formula
     sha256 "cfb18450e818a8b6b984c34fb11d5fa3ed4d55385ebe3a9a2d5ae82dfad9a89b" => :x86_64_linux
   end
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     exe = "webin-cli"


### PR DESCRIPTION
Fix `Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.` by changing `depends_on :java` to `depends_on "openjdk"`.
This PR was adapted from https://github.com/brewsci/homebrew-bio/pull/1213. It does not bump revisions, which needs to be done per formula in separate PRs.

- abyss-explorer
- artemis
- astral
- bazam
- bbtools
- beast2
- cluster-picker
- dsh-bio
- figtree
- gatk
- gepard
- jspecies
- mhap
- minced
- nextflow
- pathvisio
- pilon
- realphy
- rtg-tools
- sepp
- snpeff
- trimmomatic
- trinity
- varscan
- varsim
- webin-cli
