### PR TITLE
various formulae: add livecheck

### DIFF
--- a/Formula/adam.rb
+++ b/Formula/adam.rb
@@ -5,6 +5,12 @@ class Adam < Formula
   url "https://search.maven.org/remotecontent?filepath=org/bdgenomics/adam/adam-distribution-spark3_2.12/0.33.0/adam-distribution-spark3_2.12-0.33.0-bin.tar.gz"
   sha256 "e973c0136544659648669e1ebe29bab6c49863752dfa595722ff36d2647e054d"
 
+  livecheck do
+    url :homepage
+    strategy :github_latest
+    regex(%r{href=.*?/tag/adam-parent-spark\d+[_-]\d+(?:\.\d+)+[_-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/ale.rb
+++ b/Formula/ale.rb
@@ -7,6 +7,15 @@ class Ale < Formula
   sha256 "123457834c173f10710a0b4c2fcefd8c6fa62af11f6ad311f199c242c49e8f68"
   head "https://github.com/sc932/ALE.git"
 
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/tag/(\d{8})["' >]}i)
+    strategy :github_latest do |page, regex|
+      version = page[regex, 1]
+      version.present? ? "0.0.#{version}" : []
+    end
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/astral.rb
+++ b/Formula/astral.rb
@@ -7,6 +7,11 @@ class Astral < Formula
   license "Apache-2.0"
   head "https://github.com/smirarab/ASTRAL.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/bali-phy.rb
+++ b/Formula/bali-phy.rb
@@ -8,6 +8,11 @@ class BaliPhy < Formula
   license "GPL-2.0"
   head "https://github.com/bredelings/BAli-Phy.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/bazam.rb
+++ b/Formula/bazam.rb
@@ -6,6 +6,11 @@ class Bazam < Formula
   sha256 "396e584c95e2184025f9b9eca7377c376894f3afb4572856387866ab59c741e8"
   license "LGPL-2.1"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/bfc.rb
+++ b/Formula/bfc.rb
@@ -7,6 +7,11 @@ class Bfc < Formula
   sha256 "4f510557ea5fb9ed179bc21d9ffc85c0ae346525b56e3b72bf6204d64f6bfb8b"
   license "MIT"
 
+  livecheck do
+    url "https://raw.githubusercontent.com/lh3/bfc/master/bfc.c"
+    regex(/^#define BFC_VERSION "(r\d+)"$/i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/bioperl.rb
+++ b/Formula/bioperl.rb
@@ -6,6 +6,11 @@ class Bioperl < Formula
   sha256 "17aa3aaab2f381bbcaffdc370002eaf28f2c341b538068d6586b2276a76464a1"
   revision 3
 
+  livecheck do
+    url :stable
+    regex(/href=["']?BioPerl[._-]v?(\d+\.\d+(?:\.\d+)+(?:\.?_\d+)?)\.t/i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/bmdca.rb
+++ b/Formula/bmdca.rb
@@ -7,6 +7,11 @@ class Bmdca < Formula
   sha256 "542991c51ba1e9d74b500e09e80d43f716fe4214a24d71f580a24df667762049"
   license "GPL-3.0-only"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/bowtie.rb
+++ b/Formula/bowtie.rb
@@ -9,6 +9,11 @@ class Bowtie < Formula
   license "Artistic-2.0"
   head "https://github.com/BenLangmead/bowtie.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/cannoli.rb
+++ b/Formula/cannoli.rb
@@ -4,6 +4,12 @@ class Cannoli < Formula
   url "https://search.maven.org/remotecontent?filepath=org/bdgenomics/cannoli/cannoli-distribution-spark3_2.12/0.11.1/cannoli-distribution-spark3_2.12-0.11.1-bin.tar.gz"
   sha256 "a41f6ad894964698e28e9e22dfdfea84ef2a13dabeb38101092265d4b3ba0017"
 
+  livecheck do
+    url :homepage
+    strategy :github_latest
+    regex(%r{href=.*?/tag/cannoli-parent-spark\d+[_-]\d+(?:\.\d+)+[_-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/centrifuge.rb
+++ b/Formula/centrifuge.rb
@@ -6,6 +6,11 @@ class Centrifuge < Formula
   sha256 "71340f5c0c20dd4f7c4d98ea87f9edcbb1443fff8434e816a5465cbebaca9343"
   license "GPL-3.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/circlator.rb
+++ b/Formula/circlator.rb
@@ -9,6 +9,12 @@ class Circlator < Formula
   sha256 "927b6c156bfba6fa02db0c1173e280f85373320814c51e084170df583e604a2a"
   license "GPL-3.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)(?:[._-]|["' >])}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/easel.rb
+++ b/Formula/easel.rb
@@ -4,6 +4,12 @@ class Easel < Formula
   url "https://github.com/EddyRivasLab/easel/archive/easel-0.46.tar.gz"
   sha256 "6648ab45346c2cef4a5d4086de8e43e44f0c0f367cf92df08f4f9c88c179da42"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/easel[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/fasta.rb
+++ b/Formula/fasta.rb
@@ -6,6 +6,12 @@ class Fasta < Formula
   version "36.3.8h"
   sha256 "916b327ac996151c808bd7066dea59c4ecb6035fc27c27fa8f011d49548867d6"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/(?:fasta[._-])?v?(\d+(?:\.\d+)+[a-z]?)(?:[._-]|["' >])}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/freebayes.rb
+++ b/Formula/freebayes.rb
@@ -8,6 +8,11 @@ class Freebayes < Formula
   license "MIT"
   head "https://github.com/ekg/freebayes.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/gemma.rb
+++ b/Formula/gemma.rb
@@ -6,6 +6,11 @@ class Gemma < Formula
   sha256 "6beeed4a9e727a96fdea9e86e39bbe9cbc9f0540ad3a1053814e95b0863a7e6b"
   license "GPL-3.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -6,6 +6,11 @@ class HarvestTools < Formula
   sha256 "ffbcf0a115c74507695fd6cee4a9d5ba27a700db36b32d226521ef8dd3309264"
   head "https://github.com/marbl/harvest-tools.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "bea665dabd577ff78847689683634e581ae160fa114c6236f1cebadac9ba28d7" => :sierra

--- a/Formula/hisat2.rb
+++ b/Formula/hisat2.rb
@@ -7,6 +7,11 @@ class Hisat2 < Formula
   license "GPL-3.0"
   head "https://github.com/DaehwanKimLab/hisat2.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/iqtree.rb
+++ b/Formula/iqtree.rb
@@ -7,6 +7,10 @@ class Iqtree < Formula
   license "GPL-2.0"
   version_scheme 1
 
+  livecheck do
+    skip "1.x versions are no longer developed"
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/iva.rb
+++ b/Formula/iva.rb
@@ -6,6 +6,11 @@ class Iva < Formula
   sha256 "91ba402d0feacc88b3e34e71b4f10e0552702887e6e416076e57f95f6aaf7fad"
   license "GPL-3.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -4,6 +4,11 @@ class K8 < Formula
   url "https://github.com/attractivechaos/k8/releases/download/0.2.5/k8-0.2.5.tar.bz2"
   sha256 "a937ac44532e042cd89ac743647b592c21cfcf31679e39e5f362e81034d93d18"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/kat.rb
+++ b/Formula/kat.rb
@@ -8,6 +8,12 @@ class Kat < Formula
   revision 3
   head "https://github.com/TGAC/KAT.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/Release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "395fea7e48ae8295cd51387cb11537c67586bbfe7912f27a5b56eb0620980f92" => :catalina

--- a/Formula/kent-tools.rb
+++ b/Formula/kent-tools.rb
@@ -5,6 +5,11 @@ class KentTools < Formula
   sha256 "3608689a07a6327f5695672a804ef5f35c9d680c114b0ee947ca2a4f3b768514"
   head "git://genome-source.cse.ucsc.edu/kent.git"
 
+  livecheck do
+    url "https://hgdownload.soe.ucsc.edu/admin/exe/"
+    regex(/href=.*?userApps[._-]v?(\d+)\.src\.t/i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "8e1df6949537b6f6888f38705ff35348561815f4fe1a3b6c58e6c4d7e257c834" => :catalina

--- a/Formula/minigraph.rb
+++ b/Formula/minigraph.rb
@@ -6,6 +6,11 @@ class Minigraph < Formula
   license "MIT"
   head "https://github.com/lh3/minigraph.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/minimap2.rb
+++ b/Formula/minimap2.rb
@@ -6,6 +6,11 @@ class Minimap2 < Formula
   sha256 "b68ac8882d33cc63e9e3246775062aeb159b6990ff7f38099172c3fe6f8a2742"
   head "https://github.com/lh3/minimap2.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/mrbayes.rb
+++ b/Formula/mrbayes.rb
@@ -7,6 +7,11 @@ class Mrbayes < Formula
   license "GPL-3.0"
   head "https://github.com/NBISweden/MrBayes.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/nanopolish.rb
+++ b/Formula/nanopolish.rb
@@ -8,6 +8,11 @@ class Nanopolish < Formula
   license "MIT"
   head "https://github.com/jts/nanopolish.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/nextflow.rb
+++ b/Formula/nextflow.rb
@@ -7,6 +7,11 @@ class Nextflow < Formula
   license "Apache-2.0"
   head "https://github.com/nextflow-io/nextflow.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/portcullis.rb
+++ b/Formula/portcullis.rb
@@ -9,6 +9,11 @@ class Portcullis < Formula
   revision 1
   head "https://github.com/maplesond/portcullis.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "52b593d877a74a1268a9bb75e40dc9fcd3ecc5e197d84dffec2fc01c0ec4bd79" => :sierra

--- a/Formula/salmid.rb
+++ b/Formula/salmid.rb
@@ -6,6 +6,11 @@ class Salmid < Formula
   license "MIT"
   version_scheme 1
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/sdsl-lite.rb
+++ b/Formula/sdsl-lite.rb
@@ -9,6 +9,11 @@ class SdslLite < Formula
     tag:      "v2.1.1"
   revision 2
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/sga.rb
+++ b/Formula/sga.rb
@@ -7,6 +7,11 @@ class Sga < Formula
   revision 1
   head "https://github.com/jts/sga.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     sha256 "c557433d9f39a90ecdcc0eaccae50f590d1913d79faa23ed5625329ac61c348c" => :sierra

--- a/Formula/skesa.rb
+++ b/Formula/skesa.rb
@@ -5,6 +5,12 @@ class Skesa < Formula
   url "https://github.com/ncbi/SKESA/archive/2.4.0.tar.gz"
   sha256 "c07b56dfa394c013e519d5a246b7dee03db41d8ac912ab9ca02cf4d20bf13b15"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+    regex(%r{href=.*?/tag/(?:skesa[._-])?v?(\d+(?:\.\d+)+[a-z]?)(?:[._-]|["' >])}i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/snpeff.rb
+++ b/Formula/snpeff.rb
@@ -6,6 +6,12 @@ class Snpeff < Formula
   version "4.3t"
   sha256 "d55a7389a78312947c1e7dadf5e6897b42d3c6e942e7c1b8ec68bb35d2ae2244"
 
+  livecheck do
+    url "https://sourceforge.net/projects/snpeff/files/"
+    strategy :page_match
+    regex(/href=.*?snpEff[._-]v?(\d+(?:[._-]\d+)+[a-z]?)[._-]core\.zip/i)
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation

--- a/Formula/vt.rb
+++ b/Formula/vt.rb
@@ -8,6 +8,11 @@ class Vt < Formula
   revision 2
   head "https://github.com/atks/vt.git"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any

--- a/Formula/webin-cli.rb
+++ b/Formula/webin-cli.rb
@@ -5,6 +5,11 @@ class WebinCli < Formula
   sha256 "50862324dcc98aeef23f9789e6eac9eb37bd04378baaf2d17dfa97644c1a1e66"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     root_url "https://linuxbrew.bintray.com/bottles-bio"
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

<table><tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<pre>
adam : 0.33.0 ==> 3_2.12-0.33.0
ale : 0.0.20180904 ==> 20180904
astral : 5.7.1 ==> 697f19dbce69929ece09
bali-phy : 3.5.0 ==> 2004a-d
bazam : 1.0.1 ==> 1.0.2-submission
bfc : r181 ==> 1
bioperl : 1.007002 ==> 2.1.9
bmdca : 0.8.12 ==> 2.1
bowtie : 1.3.0 ==> 2
cannoli : 0.11.1 ==> 3_2.12-0.11.1
centrifuge : 1.0.3 ==> 39767eb57d8e175029c
circlator : 1.5.5 ==> 1.5.5-docker5
easel : 0.46 ==> 3.2
fasta : 36.3.8h ==> 36.3.8h_11-Feb-2020
freebayes : 1.3.2 ==> 9.9.13
gemma : 0.98.1 ==> 1
harvest-tools : 1.3 ==> 4
hisat2 : 2.2.1 ==> 6e8cb
iqtree : 1.6.12 ==> 2.0.7
iva : 1.0.9 ==> 1.5.0
k8 : 0.2.5 ==> 3.0.6-final
kat : 2.4.1 ==> 4
kent-tools : 401 ==> 20080107
minigraph : 0.10 ==> 1
minimap2 : 2.17 ==> 191
mrbayes : 3.2.7 ==> 3.2.7a
nanopolish : 0.12.0 ==> 2
nextflow : 20.07.1 ==> 21.01.0-edge
portcullis : 1.1.0 ==> 6
salmid : 0.1.23 ==> 0.122
sdsl-lite : 2.1.1 ==> 11v1
sga : 0.10.15 ==> 50-version
skesa : 2.4.0 ==> 2.4.0_saute.1.3.0
snpeff : 4.3t ==> 000233375.1
vt : 0.5772 ==> 2
webin-cli : 1.8.11 ==> 9415ae0ee6757f3006b6
</pre>
</td>
<td>
<pre>
adam : 0.33.0 ==> 0.33.0
ale : 0.0.20180904 ==> 0.0.20180904
astral : 5.7.1 ==> 5.7.1
bali-phy : 3.5.0 ==> 3.5.0.2
bazam : 1.0.1 ==> 1.0.1
bfc : r181 ==> r181
bioperl : 1.007002 ==> 1.7.7
bmdca : 0.8.12 ==> 0.8.12
bowtie : 1.3.0 ==> 1.3.0
cannoli : 0.11.1 ==> 0.11.1
centrifuge : 1.0.3 ==> 1.0.3
circlator : 1.5.5 ==> 1.5.5
easel : 0.46 ==> 0.48
fasta : 36.3.8h ==> 36.3.8h
freebayes : 1.3.2 ==> 1.3.3
gemma : 0.98.1 ==> 0.98.3
harvest-tools : 1.3 ==> 1.3
hisat2 : 2.2.1 ==> 2.2.1
iqtree : skipped - 1.x versions are no longer developed
iva : 1.0.9 ==> 1.0.9
k8 : 0.2.5 ==> 0.2.5
kat : 2.4.1 ==> 2.4.1
kent-tools : 401 ==> 407
minigraph : 0.10 ==> 0.14
minimap2 : 2.17 ==> 2.17
mrbayes : 3.2.7 ==> 3.2.7
nanopolish : 0.12.0 ==> 0.13.2
nextflow : 20.07.1 ==> 20.10.0
portcullis : 1.1.0 ==> 1.2.2
salmid : 0.1.23 ==> 0.1.23
sdsl-lite : 2.1.1 ==> 2.1.1
sga : 0.10.15 ==> 0.10.15
skesa : 2.4.0 ==> 2.4.0
snpeff : 4.3t ==> 4_3t
vt : 0.5772 ==> 0.57721
webin-cli : 1.8.11 ==> 3.4.0
</pre>
</td>
</tr></table>