### PR TITLE
ssm 1.4 (new formula)

### DIFF
--- a/Formula/ssm.rb
+++ b/Formula/ssm.rb
@@ -1,0 +1,26 @@
+class Ssm < Formula
+  # cite Krissinel_2004: "https://doi.org/10.1107/S0907444904026460"
+  desc "Secondary-structure matching, tool for fast protein structure alignment"
+  homepage "https://www2.mrc-lmb.cam.ac.uk"
+  url "https://www2.mrc-lmb.cam.ac.uk/personal/pemsley/coot/dependencies/ssm-1.4.tar.gz"
+  sha256 "56e7e64ed86d7d9ec59500fd34f26f881bdb9d541916d9a817c3bfb8cf0e9508"
+  license "GPL-3.0-only"
+
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "brewsci/bio/libccp4"
+  depends_on "brewsci/bio/mmdb2"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-static
+      --enable-ccp4
+    ]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    assert_match "-I#{include}", shell_output("pkg-config --cflags ssm")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Secondary-structure matching (SSM), a new tool for fast protein structure alignment. This PR depends on mmdb2 and libccp4, and will be required for Coot.