### PR TITLE
gatk 4.2.0.0

### DIFF
--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -4,8 +4,8 @@ class Gatk < Formula
   # cite McKenna_2010: "https://doi.org/10.1101/gr.107524.110"
   desc "Genome Analysis Toolkit: Variant Discovery in High-Throughput Sequencing"
   homepage "https://software.broadinstitute.org/gatk"
-  url "https://github.com/broadinstitute/gatk/releases/download/4.1.8.1/gatk-4.1.8.1.zip"
-  sha256 "42e6de5059232df1ad5785c68c39a53dc1b54afe7bb086d0129f4dc95fb182bc"
+  url "https://github.com/broadinstitute/gatk/releases/download/4.2.0.0/gatk-4.2.0.0.zip"
+  sha256 "dd11cc8e3bc7a23c2c226366428f0908c902765eabbc1c641c736c06b80aaf78"
   license "BSD-3-Clause"
 
   bottle do

--- a/Formula/gatk.rb
+++ b/Formula/gatk.rb
@@ -15,7 +15,7 @@ class Gatk < Formula
   end
 
   depends_on "openjdk"
-  depends_on "python@3.8"
+  depends_on "python@3.9"
 
   resource "count_reads.bam" do
     url "https://github.com/broadinstitute/gatk/blob/626c88732c02b0fd5f395db20c91bf2784ec54b9/src/test/resources/org/broadinstitute/hellbender/tools/count_reads.bam?raw=true"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

I've noticed that for some reason I get a new message whenever I do anything like `brew audit` or `brew install` that has a message like this:

```
Error: Failed to load cask: Formula/gatk.rb
Cask 'gatk' is unreadable: wrong constant name #<Class:0x00007faa52059d68>
Warning: Treating Formula/gatk.rb as a formula.
```
It goes away if I specify the `--formula` argument to brew but I'm not sure if there's something that needs to be updated in the formula itself or if it's just a new weird thing that's happening to me. 

