### PR TITLE
pymol: re-update python resources to suppress warnings

### DIFF
--- a/Formula/pymol.rb
+++ b/Formula/pymol.rb
@@ -7,12 +7,6 @@ class Pymol < Formula
   revision 2
   head "https://github.com/schrodinger/pymol-open-source.git"
 
-  bottle do
-    root_url "https://archive.org/download/brewsci/bottles-bio"
-    sha256 cellar: :any, catalina:     "7ed8b8b9a016e0e84a911bec38c08704c7e494541888bc96ea0e448e84588cdd"
-    sha256               x86_64_linux: "69f06cbd8855f5d3f201a98a2ee71c25cc9c4c01451b2a7ef0ee08bca7664fc7"
-  end
-
   depends_on "brewsci/bio/mmtf-cpp"
   depends_on "catch2"
   depends_on "ffmpeg" # enable export mp4 movies


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

retry updating to build pymol-2.4.0_2 bottles.