### PR TITLE
idba: Bump revision for gcc@9

### DIFF
--- a/Formula/idba.rb
+++ b/Formula/idba.rb
@@ -4,7 +4,8 @@ class Idba < Formula
   homepage "https://i.cs.hku.hk/~alse/hkubrg/projects/idba/"
   url "https://github.com/loneknightpy/idba/archive/1.1.3.tar.gz"
   sha256 "6b1746a29884f4fa17b110d94d9ead677ab5557c084a93b16b6a043dbb148709"
-  revision 2
+  license "GPL-2.0-or-later"
+  revision 3
   head "https://github.com/loneknightpy/idba.git"
 
   bottle do
@@ -16,7 +17,9 @@ class Idba < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "gcc" if OS.mac? # needs openmp
+  on_macos do
+    depends_on "gcc@9" # needs openmp
+  end
 
   fails_with :clang # needs openmp
 


### PR DESCRIPTION
Fix the error:
```
Broken dependencies:
  /usr/local/opt/gcc/lib/gcc/9/libgomp.1.dylib (gcc)
  /usr/local/opt/gcc/lib/gcc/9/libstdc++.6.dylib (gcc)
Warning: idba has broken dynamic library links
```

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

Fixes https://github.com/brewsci/homebrew-bio/issues/1303
