### PR TITLE
pymol: change pyqt to pyqt@5

### DIFF
--- a/Formula/pymol.rb
+++ b/Formula/pymol.rb
@@ -4,7 +4,7 @@ class Pymol < Formula
   homepage "https://pymol.org/"
   url "https://github.com/schrodinger/pymol-open-source/archive/v2.4.0.tar.gz"
   sha256 "5ede4ce2e8f53713c5ee64f5905b2d29bf01e4391da7e536ce8909d6b9116581"
-  revision 2
+  revision 3
   head "https://github.com/schrodinger/pymol-open-source.git"
 
   bottle do
@@ -26,7 +26,7 @@ class Pymol < Formula
   depends_on "msgpack"
   depends_on "netcdf"
   depends_on "numpy"
-  depends_on "pyqt"
+  depends_on "pyqt@5"
   depends_on "python@3.9"
   depends_on "sip"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Since the pyqt formula has been upgraded to version 6 recently, the dependency `pyqt` should be corrected to `pyqt@5`.