### PR TITLE
biointerchange 2.0.5 (new formula)

### DIFF
--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -11,6 +11,10 @@ class Biointerchange < Formula
 
   uses_from_macos "curl" => :build # linked statically
 
+  on_macos do
+    depends_on "libiconv" => :build # linked statically
+  end
+
   def install
     # NOTE: Cannot parallelize, because of ExternalProject in CMakeLists.txt
     ENV.deparallelize

--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -9,6 +9,8 @@ class Biointerchange < Formula
   depends_on "openssl@1.1" => :build # linked statically
   depends_on "python@3.9"
 
+  uses_from_macos "curl" => :build # linked statically
+
   def install
     # NOTE: Cannot parallelize, because of ExternalProject in CMakeLists.txt
     ENV.deparallelize

--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -1,0 +1,32 @@
+class Biointerchange < Formula
+  desc "Genomic linked data converter: an interchange GFF, GVF, VCF files via JSON"
+  homepage "https://github.com/BioInterchange/BioInterchangeC"
+  url "http://indie.kim/assets/biointerchange/biointerchange-2.0.5.tar.gz"
+  sha256 "36fcd19b39063fab87fb9f24a0752769ada91e81b82eb354ceb65d5147128141"
+  license "MIT"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "googletest" => :test
+  depends_on "curl"
+  depends_on "gettext"
+  depends_on "openssl@1.1"
+  depends_on "python@3.9"
+  on_macos do
+    depends_on "libiconv"
+  end
+
+  def install
+    # NOTE: Cannot parallelize, because of ExternalProject in CMakeLists.txt
+    ENV.deparallelize
+    system "cmake", *std_cmake_args
+    system "make", "libdocument-lib"
+    system "make", "biointerchange"
+    bin.install "biointerchange"
+  end
+
+  test do
+    assert_match "2.0.5+139\n", shell_output("#{bin}/biointerchange -v")
+  end
+end

--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -1,12 +1,10 @@
 class Biointerchange < Formula
-  desc "Genomic linked data converter: an interchange GFF, GVF, VCF files via JSON"
+  desc "Genomic linked-data converter: an interchange GFF, GVF, VCF files via JSON-LD"
   homepage "https://github.com/BioInterchange/BioInterchangeC"
   url "http://indie.kim/assets/biointerchange/biointerchange-2.0.5.tar.gz"
   sha256 "36fcd19b39063fab87fb9f24a0752769ada91e81b82eb354ceb65d5147128141"
   license "MIT"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "googletest" => :test
   depends_on "curl"

--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -12,6 +12,7 @@ class Biointerchange < Formula
   uses_from_macos "curl" => :build # linked statically
 
   on_macos do
+    depends_on "gettext" => :build # linked statically
     depends_on "libiconv" => :build # linked statically
   end
 

--- a/Formula/biointerchange.rb
+++ b/Formula/biointerchange.rb
@@ -6,14 +6,8 @@ class Biointerchange < Formula
   license "MIT"
 
   depends_on "cmake" => :build
-  depends_on "googletest" => :test
-  depends_on "curl"
-  depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "openssl@1.1" => :build # linked statically
   depends_on "python@3.9"
-  on_macos do
-    depends_on "libiconv"
-  end
 
   def install
     # NOTE: Cannot parallelize, because of ExternalProject in CMakeLists.txt


### PR DESCRIPTION
Second try. Pull request for @sjackman to check why I can't use `make install`, but `bin.install` works for me (locally).