### PR TITLE
CI: Use HOMEBREW_GITHUB_PACKAGES_TOKEN for artifacts

### DIFF
--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -45,7 +45,7 @@ jobs:
             artifact_id="$(curl -fs -H 'Accept: application/vnd.github.antiope-preview+json' https://api.github.com/repos/${{github.repository}}/actions/runs/$run_id/artifacts \
               | jq '.artifacts[0].id')"
             echo run_id="$run_id" artifact_id="$artifact_id"
-            curl -fL -o bottles.zip "https://${{secrets.HOMEBREW_GITHUB_API_TOKEN}}@api.github.com/repos/${{github.repository}}/actions/artifacts/$artifact_id/zip"
+            curl -fL -o bottles.zip "https://${{secrets.HOMEBREW_GITHUB_PACKAGES_TOKEN}}@api.github.com/repos/${{github.repository}}/actions/artifacts/$artifact_id/zip"
             file bottles.zip
             unzip bottles.zip
             git -C "$(brew --repo ${{github.repository}})" status


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

```console
$ curl -s "https://api.github.com/repos/brewsci/homebrew-bio/actions/artifacts/52393432/zip"
{
  "message": "You must have the actions scope to download artifacts.",
  "documentation_url": "https://docs.github.com/rest/reference/actions#download-an-artifact"
}
```

> Anyone with read access to the repository can use this endpoint.

That does not appear to be the case.

> If the repository is private you must use an access token with the repo scope.

The repository is not private.

> GitHub Apps must have the actions:read permission to use this endpoint.

There is no `actions:read` scope.
