### PR TITLE
CI: Use the GitHub Actions VM image for skopeo

### DIFF
--- a/.github/workflows/upload-bottles.yml
+++ b/.github/workflows/upload-bottles.yml
@@ -6,19 +6,13 @@ on:
 
 jobs:
   upload-bottles:
-    runs-on: ubuntu-latest
-    container:
-      image: homebrew/ubuntu16.04:master
+    runs-on: ubuntu-20.04
     env:
       HOMEBREW_GITHUB_PACKAGES_USER: LinuxbrewTestBot
       HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_GITHUB_PACKAGES_TOKEN}}
       HOMEBREW_NO_ANALYTICS: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - name: Install dependencies
-        run: |
-          apt update
-          apt install -y jq unzip
       - uses: actions/checkout@master
         with:
           fetch-depth: 100


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fix the error
```
Error: no `skopeo` and HOMEBREW_FORCE_HOMEBREW_ON_LINUX is set!
```
See https://github.com/brewsci/homebrew-bio/runs/2299025169?check_suite_focus=true#step:5:87

Skopeo is included in Ubuntu 20.10 (Groovy Gorilla), but not in Ubuntu 20.04 LTS (Focal Fossa). Skopeo is included in the GitHub Actions Ubuntu 20.04 VM image.
