### PR TITLE
pymol: update bottle to use the latest libnetcdf

### DIFF
--- a/Formula/pymol.rb
+++ b/Formula/pymol.rb
@@ -4,7 +4,7 @@ class Pymol < Formula
   homepage "https://pymol.org/"
   url "https://github.com/schrodinger/pymol-open-source/archive/v2.4.0.tar.gz"
   sha256 "5ede4ce2e8f53713c5ee64f5905b2d29bf01e4391da7e536ce8909d6b9116581"
-  revision 3
+  revision 4
   head "https://github.com/schrodinger/pymol-open-source.git"
 
   bottle do
@@ -15,7 +15,7 @@ class Pymol < Formula
 
   depends_on "brewsci/bio/mmtf-cpp"
   depends_on "catch2"
-  depends_on "ffmpeg" # enable export mp4 movies
+  depends_on "ffmpeg"
   depends_on "freeglut"
   depends_on "freetype"
   depends_on "glew"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

update bottle to use the latest libnetcdf.19.dylib instead of ilibnetcdf.18.dylib.
Please let me know if there is a better way to fix it.