### PR TITLE
pymol: install pth file to Homebrew site-packages

### DIFF
--- a/Formula/pymol.rb
+++ b/Formula/pymol.rb
@@ -4,7 +4,7 @@ class Pymol < Formula
   homepage "https://pymol.org/"
   url "https://github.com/schrodinger/pymol-open-source/archive/v2.4.0.tar.gz"
   sha256 "5ede4ce2e8f53713c5ee64f5905b2d29bf01e4391da7e536ce8909d6b9116581"
-  revision 4
+  revision 5
   head "https://github.com/schrodinger/pymol-open-source.git"
 
   bottle do
@@ -70,11 +70,14 @@ class Pymol < Formula
       --testing
     ]
     system Formula["python@3.9"].opt_bin/"python3", "setup.py", "install", *args
-
+    site_packages = "lib/python#{xy}/site-packages"
+    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
+    (prefix/site_packages/"homebrew-pymol.pth").write pth_contents
     bin.install libexec/"bin/pymol"
   end
 
   test do
     system "#{bin}/pymol", "-c"
+    system Formula["python@3.9"].opt_bin/"python3", "-c", "import pymol"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

This PR makes the pymol module available in the Homebrew site-packages (the default `PYTHONPATH` for Homebrew's python@3.9) and also adds a test to verify that the module is loadable.