### PR TITLE
arcs: Remove dependency on links-scaffolder

### DIFF
--- a/Formula/arcs.rb
+++ b/Formula/arcs.rb
@@ -20,7 +20,6 @@ class Arcs < Formula
 
   depends_on "boost" => :build
   depends_on "google-sparsehash" => :build
-  depends_on "links-scaffolder"
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

When ABySS uses `arcs` it does not require `links` and uses instead `abyss-scaffold`.
