### PR TITLE
xssp: Add deprecation date

### DIFF
--- a/Formula/xssp.rb
+++ b/Formula/xssp.rb
@@ -11,7 +11,7 @@ class Xssp < Formula
     sha256 cellar: :any, x86_64_linux: "e5c633a52565607cedbbe1d0d14255ecdc56deeb4401b6a7ea823baf09639006"
   end
 
-  deprecate! because: "has been replaced by brewsci/bio/dssp and brewsci/bio/hssp"
+  deprecate! because: "has been replaced by brewsci/bio/dssp and brewsci/bio/hssp", date: "2020-11-19"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
Fix Error: brewsci/bio/xssp: missing keyword: date

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Fixes https://github.com/brewsci/homebrew-bio/issues/1365
