### PR TITLE
Revert "[FIX] Missing permissions in CI"

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: homebrew/ubuntu16.04:master
-      options: --user root
     steps:
       - name: Update Homebrew
         run: brew update-reset


### PR DESCRIPTION
Reverts brewsci/homebrew-bio#1400 due to a new issue below.

```
[FIX] Missing permissions in CI
From https://github.com/brewsci/homebrew-bio
 * [new ref]         refs/pull/1400/head -> pr-head
pr=1400 sha1=87eb7c5fece7cd39a35841f57423efa2e9482134
run_id=1173580685 artifact_id=87205930
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

100   275    0   275    0     0    747      0 --:--:-- --:--:-- --:--:--   747
bottles.zip: Zip archive data, at least v2.0 to extract
Archive:  bottles.zip
 extracting: bottle_output.txt       
  inflating: steps_output.txt        
On branch develop
Your branch is up to date with 'origin/develop'.

nothing to commit, working tree clean
/usr/bin/skopeo
/bin/skopeo
skopeo version 1.3.0
Warning: pr-upload is a developer command, so
Homebrew's developer mode has been automatically turned on.
To turn developer mode off, run brew developer off

Error: No bottle JSON files found in the current working directory
Error: Process completed with exit code 1.
```