### PR TITLE
maxit: fix missing odb files

### DIFF
--- a/Formula/maxit.rb
+++ b/Formula/maxit.rb
@@ -21,18 +21,21 @@ class Maxit < Formula
   def install
     ENV.deparallelize
     # fix env variable "RCSBROOT" to HOMEBREW PREFIX
-    inreplace "maxit-v10.1/src/maxit.C", "rcsbroot = getenv(\"RCSBROOT\")", "rcsbroot = \"#{bin}\""
-    inreplace "maxit-v10.1/src/process_entry.C", "rcsbroot = getenv(\"RCSBROOT\")", "rcsbroot = \"#{bin}\""
-    inreplace "connect-v3.3/src/connect_main.C", "root_dir = getenv(\"RCSBROOT\")", "root_dir = \"#{bin}\""
-    # Do not delete TMPLIB
+    inreplace "maxit-v10.1/src/maxit.C", "rcsbroot = getenv(\"RCSBROOT\")", "rcsbroot = \"#{prefix}\""
+    inreplace "maxit-v10.1/src/process_entry.C", "rcsbroot = getenv(\"RCSBROOT\")", "rcsbroot = \"#{prefix}\""
+    # inreplace "connect-v3.3/src/connect_main.C", "root_dir = getenv(\"RCSBROOT\")", "root_dir = \"#{prefix}\""
+    # Do not delete tempfile
     inreplace "cifparse-obj-v7.0/Makefile", "mv", "cp"
     # trick to circumvent a CI error on Linux
+    inreplace "binary.csh", "./data/binary", "#{prefix}/data/binary"
     inreplace "Makefile", "@sh -c './binary.csh'", "@tcsh binary.csh" if OS.linux?
 
     system "make", "binary"
     # install bin and data directories
     bin.install "bin/maxit", "bin/process_entry"
     prefix.install "data"
+    (prefix/"data/binary/").install "variant.odb"
+    (prefix/"data/binary/").install "component.odb"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

fix missing odb files to run maxit completely.