### PR TITLE
New version; adds support for arm64 architectures, and uses new `install` target in makefile.

### DIFF
--- a/Formula/ale.rb
+++ b/Formula/ale.rb
@@ -2,19 +2,9 @@ class Ale < Formula
   # cite Clark_2013: "https://doi.org/10.1093/bioinformatics/bts723"
   desc "Assembly Likelihood Estimator"
   homepage "https://github.com/sc932/ALE"
-  url "https://github.com/sc932/ALE/archive/20180904.tar.gz"
-  version "0.0.20180904"
-  sha256 "123457834c173f10710a0b4c2fcefd8c6fa62af11f6ad311f199c242c49e8f68"
+  url "https://github.com/sc932/ALE/archive/20220503.tar.gz"
+  sha256 "b04a047fd3b11c0e84718bea20fe7d03f50f80a542d3b18e66c5b95983b9e559"
   head "https://github.com/sc932/ALE.git"
-
-  livecheck do
-    url :stable
-    regex(%r{href=.*?/tag/(\d{8})["' >]}i)
-    strategy :github_latest do |page, regex|
-      version = page[regex, 1]
-      version.present? ? "0.0.#{version}" : []
-    end
-  end
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"
@@ -27,7 +17,7 @@ class Ale < Formula
   def install
     cd "src" do
       system "make"
-      bin.install "ALE", "GCcompFinder", "readFileSplitter", "synthReadGen"
+      system "make", "install", "DESTDIR=#{prefix}", "PREFIX="
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----