### PR TITLE
raster3d: Use Internet Archive mirror

### DIFF
--- a/Formula/raster3d.rb
+++ b/Formula/raster3d.rb
@@ -4,7 +4,8 @@ class Raster3d < Formula
   # cite Merritt_1997: "https://doi.org/10.1016/s0076-6879(97)77028-9"
   desc "Set of tools for generating high quality raster images of proteins"
   homepage "http://www.bmsc.washington.edu/raster3d"
-  url "http://www.bmsc.washington.edu/raster3d/Raster3D_3.0-7.tar.gz"
+  url "https://web.archive.org/web/20211024200400/http://www.bmsc.washington.edu/raster3d/Raster3D_3.0-7.tar.gz"
+  mirror "http://www.bmsc.washington.edu/raster3d/Raster3D_3.0-7.tar.gz"
   sha256 "f566b499fee341db3a95229672c6afdbdb69da7faabdbe34f6e0d332d766160c"
   license "Artistic-2.0"
   revision 1


### PR DESCRIPTION
The original URL is no longer available. The Internet Archive has a copy.
See https://web.archive.org/web/20230000000000*/http://www.bmsc.washington.edu/raster3d/Raster3D_3.0-7.tar.gz

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?