### PR TITLE
repeatmasker: update h5py to 3.8.0

### DIFF
--- a/Formula/repeatmasker.rb
+++ b/Formula/repeatmasker.rb
@@ -35,8 +35,8 @@ class Repeatmasker < Formula
   end
 
   resource "h5py" do
-    url "https://files.pythonhosted.org/packages/c5/40/7cf58e6230f0e76699f011c6d293dd47755997709a303a4e644823f3a753/h5py-3.7.0.tar.gz"
-    sha256 "3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3"
+    url "https://files.pythonhosted.org/packages/69/f4/3172bb63d3c57e24aec42bb93fcf1da4102752701ab5ad10b3ded00d0c5b/h5py-3.8.0.tar.gz"
+    sha256 "6fead82f0c4000cf38d53f9c030780d81bfa0220218aee13b90b7701c937d95f"
   end
 
   def python3


### PR DESCRIPTION
Otherwise installation ends in an error "wrong file driver version" probably because of hdf5 updates.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
