### PR TITLE
cluster-picker: use https:// in homepage url

### DIFF
--- a/Formula/cluster-picker.rb
+++ b/Formula/cluster-picker.rb
@@ -1,7 +1,7 @@
 class ClusterPicker < Formula
   # cite RagonnetCronin_2013: "https://doi.org/10.1186/1471-2105-14-317"
   desc "Pick/describe HIV clusters in phylogenetic trees"
-  homepage "http://hiv.bio.ed.ac.uk/software.html"
+  homepage "https://hiv.bio.ed.ac.uk/software.html"
   url "https://github.com/emmahodcroft/cluster-picker-and-cluster-matcher/raw/master/release/ClusterPicker_1.2.5.jar"
   sha256 "8698b2c1d57d53843534780f860827f09b6bce9a323e2363085597c00e20cbb7"
   license "GPL-3.0"


### PR DESCRIPTION
Recommended in https://repology.org/repository/homebrew_tap_brewsci_bio/problems

- [X] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
