### PR TITLE
r2r: add trailing slash to homepage url to avoid redirection

### DIFF
--- a/Formula/r2r.rb
+++ b/Formula/r2r.rb
@@ -1,7 +1,7 @@
 class R2r < Formula
   # cite Weinberg_2011: "https://doi.org/10.1186/1471-2105-12-3"
   desc "Software to speed depiction of aesthetic consensus RNA secondary structures"
-  homepage "https://sourceforge.net/projects/weinberg-r2r"
+  homepage "https://sourceforge.net/projects/weinberg-r2r/"
   url "https://downloads.sourceforge.net/project/weinberg-r2r/R2R-1.0.6.tgz"
   sha256 "1ba8f51db92866ebe1aeb3c056f17489bceefe2f67c5c0bbdfbddc0eee17743d"
 


### PR DESCRIPTION
> Homepage link https://sourceforge.net/projects/weinberg-r2r needs a trailing slash added, otherwise there's a javascript redirect. 

As recommended in https://repology.org/repository/homebrew_tap_brewsci_bio/problems

- [X] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----
