### PR TITLE
Update maxit.rb

### DIFF
--- a/Formula/maxit.rb
+++ b/Formula/maxit.rb
@@ -2,7 +2,7 @@ class Maxit < Formula
   desc "Assists in the processing and curation of macromolecular structure data"
   homepage "https://sw-tools.rcsb.org/apps/MAXIT"
   url "https://sw-tools.rcsb.org/apps/MAXIT/maxit-v11.100-prod-src.tar.gz"
-  sha256 "373540082e02203e6b6ba43190d393da854641521d9b3843157f785273001523"
+  sha256 "e5c6656ea00a6716ca4c390cbd527ebb67a4837ea81c516220853fbb15c8af1d"
   license :cannot_represent
   revision 1
 


### PR DESCRIPTION
Sha256 is different from the packages downloaded. 

```
(base) ➜  ~ wget https://sw-tools.rcsb.org/apps/MAXIT/maxit-v11.100-prod-src.tar.gz --2023-11-25 15:01:14--  https://sw-tools.rcsb.org/apps/MAXIT/maxit-v11.100-prod-src.tar.gz Resolving sw-tools.rcsb.org (sw-tools.rcsb.org)... 128.6.178.46 Connecting to sw-tools.rcsb.org (sw-tools.rcsb.org)|128.6.178.46|:443... connected. HTTP request sent, awaiting response... 200 OK
Length: 75123919 (72M) [application/x-gzip]
Saving to: ‘maxit-v11.100-prod-src.tar.gz’

maxit-v11.100-prod-src.tar.gz                            100%[===============================================================================================================================>]  71,64M   102MB/s    in 0,7s

2023-11-25 15:01:15 (102 MB/s) - ‘maxit-v11.100-prod-src.tar.gz’ saved [75123919/75123919]

(base) ➜  ~ shasum -a 256 maxit-v11.100-prod-src.tar.gz 
e5c6656ea00a6716ca4c390cbd527ebb67a4837ea81c516220853fbb15c8af1d  maxit-v11.100-prod-src.tar.gz
```
