### PR TITLE
libsbml 5.20.2 (new formula)

### DIFF
--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -5,8 +5,10 @@ class Libsbml < Formula
   sha256 "a196cab964b0b41164d4118ef20523696510bbfd264a029df00091305a1af540"
   license "LGPL-2.1-only"
 
+  depends_on "check" => :build
   depends_on "cmake" => :build
-  depends_on "check"
+  depends_on "pkg-config" => :build
+  depends_on "swig" => :build
 
   if OS.mac?
     uses_from_macos "bzip2"

--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -28,7 +28,7 @@ class Libsbml < Formula
       -DENABLE_QUAL=ON
       -DENABLE_RENDER=ON
     ]
-
+    args << "-DLIBSBML_DEPENDENCY_DIR=#{HOMEBREW_PREFIX}"
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -8,23 +8,23 @@ class Libsbml < Formula
   depends_on "check" => :build
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "swig" => :build
 
-  if OS.mac?
-    uses_from_macos "bzip2"
-    uses_from_macos "libxml2"
-    uses_from_macos "zlib"
-  else
-    depends_on "bzip2"
-    depends_on "libxml2"
-    depends_on "zlib"
-  end
+  uses_from_macos "bzip2"
+  uses_from_macos "libxml2"
 
   def install
     args = %w[
+      -DWITH_SWIG=OFF
+      -DWITH_ZLIB=OFF
+      -DWITH_BZIP2=ON
+      -DENABLE_COMP=ON
       -DENABLE_FBC=ON
       -DENABLE_GROUPS=ON
-      -DWITH_LIBXML=TRUE
+      -DENABLE_L3V2EXTENDEDMATH=ON
+      -DENABLE_LAYOUT=ON
+      -DENABLE_MULTI=ON
+      -DENABLE_QUAL=ON
+      -DENABLE_RENDER=ON
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -10,12 +10,10 @@ class Libsbml < Formula
 
   if OS.mac?
     uses_from_macos "bzip2"
-    uses_from_macos "libiconv"
     uses_from_macos "libxml2"
     uses_from_macos "zlib"
   else
     depends_on "bzip2"
-    depends_on "libiconv"
     depends_on "libxml2"
     depends_on "zlib"
   end

--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -1,0 +1,69 @@
+class Libsbml < Formula
+  desc "Library for handling SBML (Systems Biology Markup Language)"
+  homepage "https://sbml.org/software/libsbml"
+  url "https://github.com/sbmlteam/libsbml/archive/refs/tags/v5.20.2.tar.gz"
+  sha256 "a196cab964b0b41164d4118ef20523696510bbfd264a029df00091305a1af540"
+  license "LGPL-2.1-only"
+
+  depends_on "cmake" => :build
+  depends_on "check"
+
+  if OS.mac?
+    uses_from_macos "bzip2"
+    uses_from_macos "libiconv"
+    uses_from_macos "libxml2"
+    uses_from_macos "zlib"
+  else
+    depends_on "bzip2"
+    depends_on "libiconv"
+    depends_on "libxml2"
+    depends_on "zlib"
+  end
+
+  def install
+    args = %w[
+      -DENABLE_FBC=ON
+      -DENABLE_GROUPS=ON
+      -DWITH_LIBXML=TRUE
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <sbml/SBMLTypes.h>
+      #include <sbml/packages/fbc/common/FbcExtensionTypes.h>
+      #include <sbml/packages/groups/common/GroupsExtensionTypes.h>
+
+      LIBSBML_CPP_NAMESPACE_USE
+
+      int main(int argc,char** argv)
+      {
+        SBMLNamespaces sbmlns(3,2);
+
+        sbmlns.addPkgNamespace("fbc",1);
+        sbmlns.addPkgNamespace("groups",1);
+
+        // create the document
+
+        SBMLDocument *document = new SBMLDocument(&sbmlns);
+        document->setPackageRequired("fbc", false);
+        document->setPackageRequired("groups", false);
+
+        // create the model
+        Model* model = document->createModel();
+
+        // basic test
+        model->setId("Homebrew_SBMLtest");
+        std::cout << model->getId() << std::endl;
+
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++17", "-L#{lib}", "-I#{include}", "test.cpp", "-o", "test", "-lsbml"
+    assert_equal "Homebrew_SBMLtest", shell_output("./test").strip
+  end
+end

--- a/Formula/libsbml.rb
+++ b/Formula/libsbml.rb
@@ -13,6 +13,8 @@ class Libsbml < Formula
   uses_from_macos "libxml2"
 
   def install
+    # avoid an error "invalid conversion from ‘const xmlError*’"
+    ENV.append_to_cflags "-fpermissive" if OS.linux?
     args = %w[
       -DWITH_SWIG=OFF
       -DWITH_ZLIB=OFF


### PR DESCRIPTION
libsbml is a library for handling text files in Systems Biology Markup Language (SBML).

A brief explanation for the additional configuration flags (-DENABLE_FBC=ON -DENABLE_GROUPS=ON):

These enable two optional extensions for the libsbml library, namely "fbc" and "groups". Both are relevant for the research community that uses linear programming to predict metabolic processes in living cells (i.e., flux balance analysis). apt and dnf linux builds also include these two extensions.

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

This is my first formula. Any feedback is welcome.