### PR TITLE
kissplice 2.6.5 (new formula)

### DIFF
--- a/Formula/kissplice.rb
+++ b/Formula/kissplice.rb
@@ -1,0 +1,52 @@
+class Kissplice < Formula
+  # cite Sacomoto_2012: https://doi.org/10.1186/1471-2105-13-S6-S5
+  desc "Local transcriptome assembler for SNPs, indels and AS events"
+  homepage "https://kissplice.prabi.fr"
+  url "https://gitlab.inria.fr/erable/kissplice.git",
+      tag:      "2.6.5",
+      revision: "00cb99c3b1971866089ef0439526647d328115d0"
+  license "CECILL-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "python@3.12" # Python application but only uses standard packages
+
+  uses_from_macos "zlib"
+
+  def install
+    # Fix the content of 2 template files in bcalm that store the compiler path.
+    # The bcalm git is created by cmake ExternalProject step, clear during PATCH_COMMAND.
+    (buildpath/"empty_settings_file").write "Removed but must be non-empty"
+    (buildpath/"fixed_buildinfo_header").write <<-EOF
+      #define STR_LIBRARY_VERSION     "${gatb-core-version}"
+      #define STR_COMPILATION_DATE    "${gatb-core-date}"
+      #define STR_COMPILATION_FLAGS   "${gatb-core-flags}"
+      #define STR_COMPILER            "c compiler  (${CMAKE_CXX_COMPILER_VERSION})"
+      #define STR_OPERATING_SYSTEM    "${CMAKE_SYSTEM}"
+    EOF
+    inreplace "CMakeLists.txt", "# This is run inside bcalm build dir.", <<-EOF
+      PATCH_COMMAND "${CMAKE_COMMAND}" -E copy #{buildpath}/empty_settings_file
+        gatb-core/gatb-core/thirdparty/hdf5/config/cmake/libhdf5.settings.cmake.in
+        && "${CMAKE_COMMAND}" -E copy #{buildpath}/fixed_buildinfo_header
+        gatb-core/gatb-core/src/gatb/system/api/build_info.hpp.in
+    EOF
+
+    system "cmake", "-S", ".", "-B", "build/", "-DUSE_BUNDLED_BCALM=ON", *std_cmake_args
+    system "cmake", "--build", "build/"
+    system "cmake", "--install", "build/"
+  end
+
+  test do
+    resource "git" do
+      url "https://gitlab.inria.fr/erable/kissplice.git",
+          tag:      "2.6.5",
+          revision: "00cb99c3b1971866089ef0439526647d328115d0"
+    end
+
+    resource("git").stage do
+      # Run sample example from the git data
+      system "#{bin}/kissplice",
+        "-r", "sample_example/mock1.fq", "-r", "sample_example/mock2.fq",
+        "-r", "sample_example/virus1.fq", "-r", "sample_example/virus2.fq"
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source FORMULA`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict FORMULA` (after doing `brew install FORMULA`)?

-----

Kissplice was packaged before the migration to brewsci/bio : https://github.com/brewsci/homebrew-science/blob/master/Formula/kissplice.rb

Modernize packaging with the current configuration :
- gitlab
- modern cmake
- run sample example as test stage. another possibility is running make test in install

Kissplice depends on bcalm, but uses an internal build that is patched to work with ARM MacOS.
The patch has been submitted to bcalm upstream but in the meantime the current bcalm formula does not build on ARM MacOS.

Sadly bcalm embeds the shims directory through the C/C++ compiler path which makes `brew audit` fail.
I have added patches to fix this but this is quite ugly.
In the long run it would be better to do it in the bcalm formula and then depend on it, but this would have to wait for bcalm upstream to also fix the ARM MacOS build failure to be useful.