### PR TITLE
autodock-vina: fix boost errors

### DIFF
--- a/Formula/autodock-vina.rb
+++ b/Formula/autodock-vina.rb
@@ -30,8 +30,8 @@ class AutodockVina < Formula
     inreplace "src/split/split.cpp", "#include <boost/filesystem/convenience.hpp> ", ""
     inreplace "src/lib/vina.h", "#include <boost/filesystem/convenience.hpp> ", ""
     inreplace "src/lib/parallel_progress.h" do |s|
-      s.gsub! "#include <boost/process.hpp>", "#include <boost/timer/progress_display.hpp>"
-      s.gsub! "src/lib/parallel_progress.h", "boost::progress_display", "boost::timer::progress_display"
+      s.gsub! "#include <boost/progress.hpp>", "#include <boost/timer/progress_display.hpp>"
+      s.gsub! "boost::progress_display", "boost::timer::progress_display"
     end
     if OS.mac?
       cd "build/mac/release" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
