### PR TITLE
voronota: Remove unnecessary dependencies

### DIFF
--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -11,6 +11,7 @@ class Voronota < Formula
   depends_on "open-mpi" => :optional
 
   def install
+    ENV.cxx11
     args = std_cmake_args + [
       "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
       "-DCMAKE_INSTALL_PREFIX=#{prefix}",
@@ -23,7 +24,6 @@ class Voronota < Formula
     if build.with?("openmp")
       if OS.mac?
         # use Apple Clang + libomp
-        ENV["CXX"] = "clang++"
         args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
         args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
       else

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,8 +7,8 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
-  depends_on "open-mpi" => :optional
   depends_on "libomp" if OS.mac?
+  depends_on "open-mpi" => :optional
 
   def install
     args = std_cmake_args + [

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -11,22 +11,22 @@ class Voronota < Formula
   depends_on "boost"
   depends_on "glew"
   depends_on "glfw"
-  depends_on "python3"
+  depends_on "python"
 
   on_macos do
     depends_on "libomp"
   end
 
   on_linux do
-    depends_on "gcc"
+    depends_on "gcc"  # for OpenMP support
     depends_on "mesa"
   end
 
   def install
     ENV.cxx11
-    
+
     if OS.mac?
-      ENV.append "CXXFLAGS", 
+      ENV.append "CXXFLAGS",
         "-Xpreprocessor -fopenmp -I#{libomp.opt_include} -L#{libomp.opt_lib} -lomp"
     elsif OS.linux?
       ENV.append "CXXFLAGS", "-fopenmp"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -26,7 +26,7 @@ class Voronota < Formula
   end
 
   on_linux do
-    depends_on "gcc"  # for OpenMP support
+    depends_on "gcc" # for OpenMP support
     depends_on "mesa"
   end
 

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -44,6 +44,6 @@ class Voronota < Formula
   end
 
   test do
-    assert_match "Commands:", shell_output("#{bin}/voronota --help 2>&1")
+    assert_match "Commands:", shell_output("#{bin}/voronota --help 2>&1", 1)
   end
 end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -8,6 +8,7 @@ class Voronota < Formula
 
   depends_on "cmake" => :build
   depends_on "libomp" if OS.mac?
+  depends_on "glfw"
   depends_on "open-mpi" => :optional
 
   def install

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -11,7 +11,6 @@ class Voronota < Formula
   depends_on "glew"
   depends_on "glfw"
   depends_on "glm"
-  depends_on "open-mpi"
 
   def install
     ENV.cxx11

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -44,6 +44,6 @@ class Voronota < Formula
   end
 
   test do
-    assert_match "Commands:", shell_output("#{bin}/voronota --help --help 2>&1")
+    assert_match "Commands:", shell_output("#{bin}/voronota --help 2>&1")
   end
 end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -16,10 +16,8 @@ class Voronota < Formula
 
   depends_on "cmake" => :build
   depends_on "glm" => :build
-  depends_on "boost"
   depends_on "glew"
   depends_on "glfw"
-  depends_on "python"
 
   on_macos do
     depends_on "libomp"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,24 +7,41 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
+  depends_on "glm" => :build
   depends_on "boost"
   depends_on "glew"
   depends_on "glfw"
-  depends_on "glm"
+  depends_on "python3"
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "gcc"
+    depends_on "mesa"
+  end
 
   def install
     ENV.cxx11
+    
+    if OS.mac?
+      ENV.append "CXXFLAGS", 
+        "-Xpreprocessor -fopenmp -I#{libomp.opt_include} -L#{libomp.opt_lib} -lomp"
+    elsif OS.linux?
+      ENV.append "CXXFLAGS", "-fopenmp"
+    end
 
-    args = std_cmake_args + [
-      "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-      "-DCMAKE_INSTALL_PREFIX=#{prefix}",
-      "-DCMAKE_BUILD_TYPE=Release",
-      "-DEXPANSION_JS=ON",
-      "-DEXPANSION_LT=ON",
-      "-DEXPANSION_GL=ON",
-      "-DCMAKE_CXX_COMPILER=#{ENV["CXX"]}",
-      "-DENABLE_MPI=OFF",
+    args = std_cmake_args + %W[
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
+      -DCMAKE_CXX_FLAGS=#{ENV["CXXFLAGS"]}
+      -DEXPANSION_JS=ON
+      -DEXPANSION_LT=ON
+      -DEXPANSION_GL=ON
     ]
+    # puts args
+    # exit
 
     system "cmake", ".", *args
     system "make"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,15 +7,15 @@ class Voronota < Formula
   version "1.29.4370"
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
+  depends_on "cmake" => :build
+  depends_on "open-mpi" if build.with?("mpi")
+  depends_on "gcc" if build.with?("openmp")
+
   option "with-js",      "Enable Voronota-JS expansion"
   option "with-lt",      "Enable Voronota-LT expansion"
   option "with-gl",      "Enable Voronota-GL expansion"
   option "with-openmp",  "Compile with OpenMP support"
   option "with-mpi",     "Compile with MPI support"
-
-  depends_on "cmake" => :build
-  depends_on "open-mpi" if build.with?("mpi")
-  depends_on "gcc" if build.with?("openmp")
 
   def install
     args = std_cmake_args + [
@@ -45,6 +45,6 @@ class Voronota < Formula
   end
 
   test do
-    assert_match "Commands:", shell_output("#{bin}/voronota --help")
+    assert_match "Commands:", shell_output("#{bin}/voronota --help --help 2>&1")
   end
 end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,6 +7,8 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
+  depends_on "gcc" => :build if OS.linux?
+  depends_on "boost"
   depends_on "glew"
   depends_on "glfw"
   depends_on "glm"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -2,7 +2,6 @@ class Voronota < Formula
   desc "Compute Voronoi diagram vertices for macromolecular structures"
   homepage "https://github.com/kliment-olechnovic/voronota"
   url "https://github.com/kliment-olechnovic/voronota/archive/refs/tags/v1.29.4370.tar.gz"
-  version "1.29.4370"
   sha256 "c7b55f1de0a36502121d87d5fe980dbc13223e0323c86a644cf1f3b39de52eda"
   license "MIT"
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -6,31 +6,31 @@ class Voronota < Formula
   license "MIT"
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
-  option "with-js", "Enable Voronota-JS expansion"
-  option "with-lt", "Enable Voronota-LT expansion"
-  option "with-gl", "Enable Voronota-GL expansion"
-  option "with-openmp", "Compile with OpenMP support"
-  option "with-mpi", "Compile with MPI support"
-
   depends_on "cmake" => :build
-  depends_on "gcc" => :optional
   depends_on "open-mpi" => :optional
+  depends_on "libomp" if OS.mac?
 
   def install
     args = std_cmake_args + [
       "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
       "-DCMAKE_INSTALL_PREFIX=#{prefix}",
       "-DCMAKE_BUILD_TYPE=Release",
-      "-DEXPANSION_JS=#{build.with?("js")  ? "ON" : "OFF"}",
-      "-DEXPANSION_LT=#{build.with?("lt")  ? "ON" : "OFF"}",
-      "-DEXPANSION_GL=#{build.with?("gl")  ? "ON" : "OFF"}",
-      "-DUSE_TR1=#{build.with?("tr1")      ? "1"  : "0"}",
+      "-DEXPANSION_JS=ON",
+      "-DEXPANSION_LT=ON",
+      "-DEXPANSION_GL=ON",
     ]
 
     if build.with?("openmp")
-      # Homebrew GCC provides OpenMP
-      ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
-      args << "-DCMAKE_CXX_FLAGS=-fopenmp"
+      if OS.mac?
+        # use Apple Clang + libomp
+        ENV["CXX"] = "clang++"
+        args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
+        args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
+      else
+        # Homebrew GCC provides OpenMP on Linux
+        ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
+        args << "-DCMAKE_CXX_FLAGS=-fopenmp"
+      end
     end
 
     if build.with?("mpi")

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -9,6 +9,7 @@ class Voronota < Formula
   depends_on "cmake" => :build
   depends_on "glew"
   depends_on "glfw"
+  depends_on "glm"
   depends_on "libomp" if OS.mac?
   depends_on "open-mpi"
 

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -35,7 +35,7 @@ class Voronota < Formula
 
     if OS.mac?
       ENV.append "CXXFLAGS",
-        "-Xpreprocessor -fopenmp -I#{libomp.opt_include} -L#{libomp.opt_lib} -lomp"
+        "-Xpreprocessor -fopenmp -I#{Formula["libomp"].opt_include} -L#{Formula["libomp"].opt_lib} -lomp"
     elsif OS.linux?
       ENV.append "CXXFLAGS", "-fopenmp"
     end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -35,7 +35,9 @@ class Voronota < Formula
 
     if OS.mac?
       ENV.append "CXXFLAGS",
-        "-Xpreprocessor -fopenmp -I#{Formula["libomp"].opt_include} -L#{Formula["libomp"].opt_lib} -lomp"
+        "-I#{Formula["libomp"].opt_include} -Xpreprocessor -fopenmp"
+      ENV.append "LDFLAGS",
+        "-L#{Formula["libomp"].opt_lib} -lomp"
     elsif OS.linux?
       ENV.append "CXXFLAGS", "-fopenmp"
     end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -1,0 +1,48 @@
+class Voronota < Formula
+  desc "Compute Voronoi diagram vertices for macromolecular structures"
+  homepage "https://github.com/kliment-olechnovic/voronota"
+  url "https://github.com/kliment-olechnovic/voronota/archive/refs/tags/v1.29.4370.tar.gz"
+  sha256 "c7b55f1de0a36502121d87d5fe980dbc13223e0323c86a644cf1f3b39de52eda"
+  license "MIT"
+  version "1.29.4370"
+  head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
+
+#   option "with-js",      "Enable Voronota-JS expansion"
+#   option "with-lt",      "Enable Voronota-LT expansion"
+#   option "with-gl",      "Enable Voronota-GL expansion"
+#   option "with-openmp",  "Compile with OpenMP support"
+#   option "with-mpi",     "Compile with MPI support"
+
+  depends_on "cmake" => :build
+  depends_on "open-mpi" if build.with?("mpi")
+  depends_on "gcc" if build.with?("openmp")
+
+  def install
+    args = std_cmake_args + [
+      "-DPREFIX=#{prefix}",
+      "-DEXPANSION_JS=#{build.with?("js")  ? "ON" : "OFF"}",
+      "-DEXPANSION_LT=#{build.with?("lt")  ? "ON" : "OFF"}",
+      "-DEXPANSION_GL=#{build.with?("gl")  ? "ON" : "OFF"}",
+      "-DUSE_TR1=#{build.with?("tr1")      ? "1"  : "0"}"
+    ]
+
+    if build.with?("openmp")
+      # Homebrew GCC provides OpenMP
+      ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
+      args << "-DCMAKE_CXX_FLAGS=-fopenmp"
+    end
+
+    if build.with?("mpi")
+      ENV["MPICXX"] = "#{Formula["open-mpi"].opt_bin}/mpic++"
+      args << "-DENABLE_MPI=ON"
+    end
+
+    system "cmake", ".", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/voronota --help")
+  end
+end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,9 +7,10 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
+  depends_on "glew"
   depends_on "glfw"
   depends_on "libomp" if OS.mac?
-  depends_on "open-mpi" => :optional
+  depends_on "open-mpi"
 
   def install
     ENV.cxx11
@@ -22,22 +23,18 @@ class Voronota < Formula
       "-DEXPANSION_GL=ON",
     ]
 
-    if build.with?("openmp")
-      if OS.mac?
-        # use Apple Clang + libomp
-        args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
-        args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
-      else
-        # Homebrew GCC provides OpenMP on Linux
-        ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
-        args << "-DCMAKE_CXX_FLAGS=-fopenmp"
-      end
+    if OS.mac?
+      # use Apple Clang + libomp
+      args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
+      args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
+    else
+      # Homebrew GCC provides OpenMP on Linux
+      ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
+      args << "-DCMAKE_CXX_FLAGS=-fopenmp"
     end
 
-    if build.with?("mpi")
-      ENV["MPICXX"] = "#{Formula["open-mpi"].opt_bin}/mpic++"
-      args << "-DENABLE_MPI=ON"
-    end
+    ENV["MPICXX"] = "#{Formula["open-mpi"].opt_bin}/mpic++"
+    args << "-DENABLE_MPI=ON"
 
     system "cmake", ".", *args
     system "make"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -11,11 +11,11 @@ class Voronota < Formula
   depends_on "glew"
   depends_on "glfw"
   depends_on "glm"
-  depends_on "libomp" if OS.mac?
   depends_on "open-mpi"
 
   def install
     ENV.cxx11
+
     args = std_cmake_args + [
       "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
       "-DCMAKE_INSTALL_PREFIX=#{prefix}",
@@ -23,14 +23,9 @@ class Voronota < Formula
       "-DEXPANSION_JS=ON",
       "-DEXPANSION_LT=ON",
       "-DEXPANSION_GL=ON",
+      "-DCMAKE_CXX_COMPILER=#{ENV["CXX"]}",
+      "-DENABLE_MPI=OFF"
     ]
-
-    args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
-    args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
-
-
-    ENV["MPICXX"] = "#{Formula["open-mpi"].opt_bin}/mpic++"
-    args << "-DENABLE_MPI=ON"
 
     system "cmake", ".", *args
     system "make"

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,8 +7,8 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
-  depends_on "libomp" if OS.mac?
   depends_on "glfw"
+  depends_on "libomp" if OS.mac?
   depends_on "open-mpi" => :optional
 
   def install

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,11 +7,11 @@ class Voronota < Formula
   version "1.29.4370"
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
-#   option "with-js",      "Enable Voronota-JS expansion"
-#   option "with-lt",      "Enable Voronota-LT expansion"
-#   option "with-gl",      "Enable Voronota-GL expansion"
-#   option "with-openmp",  "Compile with OpenMP support"
-#   option "with-mpi",     "Compile with MPI support"
+  option "with-js",      "Enable Voronota-JS expansion"
+  option "with-lt",      "Enable Voronota-LT expansion"
+  option "with-gl",      "Enable Voronota-GL expansion"
+  option "with-openmp",  "Compile with OpenMP support"
+  option "with-mpi",     "Compile with MPI support"
 
   depends_on "cmake" => :build
   depends_on "open-mpi" if build.with?("mpi")
@@ -19,7 +19,9 @@ class Voronota < Formula
 
   def install
     args = std_cmake_args + [
-      "-DPREFIX=#{prefix}",
+      "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+      "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+      "-DCMAKE_BUILD_TYPE=Release",
       "-DEXPANSION_JS=#{build.with?("js")  ? "ON" : "OFF"}",
       "-DEXPANSION_LT=#{build.with?("lt")  ? "ON" : "OFF"}",
       "-DEXPANSION_GL=#{build.with?("gl")  ? "ON" : "OFF"}",
@@ -43,6 +45,6 @@ class Voronota < Formula
   end
 
   test do
-    assert_match "Usage", shell_output("#{bin}/voronota --help")
+    assert_match "Commands:", shell_output("#{bin}/voronota --help")
   end
 end

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -2,20 +2,20 @@ class Voronota < Formula
   desc "Compute Voronoi diagram vertices for macromolecular structures"
   homepage "https://github.com/kliment-olechnovic/voronota"
   url "https://github.com/kliment-olechnovic/voronota/archive/refs/tags/v1.29.4370.tar.gz"
+  version "1.29.4370"
   sha256 "c7b55f1de0a36502121d87d5fe980dbc13223e0323c86a644cf1f3b39de52eda"
   license "MIT"
-  version "1.29.4370"
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
-  depends_on "cmake" => :build
-  depends_on "open-mpi" if build.with?("mpi")
-  depends_on "gcc" if build.with?("openmp")
+  option "with-js", "Enable Voronota-JS expansion"
+  option "with-lt", "Enable Voronota-LT expansion"
+  option "with-gl", "Enable Voronota-GL expansion"
+  option "with-openmp", "Compile with OpenMP support"
+  option "with-mpi", "Compile with MPI support"
 
-  option "with-js",      "Enable Voronota-JS expansion"
-  option "with-lt",      "Enable Voronota-LT expansion"
-  option "with-gl",      "Enable Voronota-GL expansion"
-  option "with-openmp",  "Compile with OpenMP support"
-  option "with-mpi",     "Compile with MPI support"
+  depends_on "cmake" => :build
+  depends_on "gcc" => :optional
+  depends_on "open-mpi" => :optional
 
   def install
     args = std_cmake_args + [
@@ -25,7 +25,7 @@ class Voronota < Formula
       "-DEXPANSION_JS=#{build.with?("js")  ? "ON" : "OFF"}",
       "-DEXPANSION_LT=#{build.with?("lt")  ? "ON" : "OFF"}",
       "-DEXPANSION_GL=#{build.with?("gl")  ? "ON" : "OFF"}",
-      "-DUSE_TR1=#{build.with?("tr1")      ? "1"  : "0"}"
+      "-DUSE_TR1=#{build.with?("tr1")      ? "1"  : "0"}",
     ]
 
     if build.with?("openmp")

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -24,7 +24,7 @@ class Voronota < Formula
       "-DEXPANSION_LT=ON",
       "-DEXPANSION_GL=ON",
       "-DCMAKE_CXX_COMPILER=#{ENV["CXX"]}",
-      "-DENABLE_MPI=OFF"
+      "-DENABLE_MPI=OFF",
     ]
 
     system "cmake", ".", *args

--- a/Formula/voronota.rb
+++ b/Formula/voronota.rb
@@ -7,7 +7,6 @@ class Voronota < Formula
   head "https://github.com/kliment-olechnovic/voronota.git", branch: "master"
 
   depends_on "cmake" => :build
-  depends_on "gcc" => :build if OS.linux?
   depends_on "boost"
   depends_on "glew"
   depends_on "glfw"
@@ -26,15 +25,9 @@ class Voronota < Formula
       "-DEXPANSION_GL=ON",
     ]
 
-    if OS.mac?
-      # use Apple Clang + libomp
-      args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
-      args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
-    else
-      # Homebrew GCC provides OpenMP on Linux
-      ENV["CXX"] = Formula["gcc"].opt_bin/"g++"
-      args << "-DCMAKE_CXX_FLAGS=-fopenmp"
-    end
+    args << "-DCMAKE_CXX_FLAGS=-Xpreprocessor -fopenmp"
+    args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp"
+
 
     ENV["MPICXX"] = "#{Formula["open-mpi"].opt_bin}/mpic++"
     args << "-DENABLE_MPI=ON"


### PR DESCRIPTION
This pull request updates the `Formula/voronota.rb` file to streamline dependencies and improve build flag organization. The most important changes include removing unused dependencies and restructuring compiler and linker flags for better clarity and maintainability.

### Dependency updates:
* Removed `boost` and `python` as dependencies, as they are no longer required for the formula. (`[Formula/voronota.rbL20-L23](diffhunk://#diff-48dc80a2cb9eefd17347b460752e589904a52e171413abf3dc588faa50a80ed9L20-L23)`)

### Build flag improvements:
* Split `CXXFLAGS` and `LDFLAGS` for macOS builds to improve clarity by separating include paths and linker flags. (`[Formula/voronota.rbL39-R39](diffhunk://#diff-48dc80a2cb9eefd17347b460752e589904a52e171413abf3dc588faa50a80ed9L39-R39)`)

---

- [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [ ] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [ ] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
