### PR TITLE
openstructure: Replace a dependency on MacOS

### DIFF
--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -9,7 +9,6 @@ class Openstructure < Formula
   license "LGPL-3.0-or-later"
 
   depends_on "cmake" => :build
-  depends_on "openblas" => :build
   depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
   depends_on "boost"
@@ -28,6 +27,7 @@ class Openstructure < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "llvm" if OS.mac?
+  depends_on "openblas"
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "postgresql@15" if OS.mac?
   depends_on "pyqt@5"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -62,11 +62,11 @@ class Openstructure < Formula
     if OS.mac?
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
       ENV.append "LDFLAGS",
-        "-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
+        "-undefined dynamic_lookup -Wl,-export_dynamic"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.append "LDFLAGS",
-        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -lpython#{py_ver} -L#{Formula["zlib"].opt_lib}"
+        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
     end
@@ -123,6 +123,8 @@ class Openstructure < Formula
         -DENABLE_INFO=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
+      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
+      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
@@ -171,6 +173,8 @@ class Openstructure < Formula
         -DUSE_DOUBLE_PRECISION=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
+      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
+      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -33,7 +33,6 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
-  depends_on "zlib" if OS.linux?
 
   uses_from_macos "zlib"
 
@@ -102,15 +101,20 @@ class Openstructure < Formula
     openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
     rpaths = [
-      lib,
+      "$ORIGIN/../${LIB_DIR}",
       openmm_libs_base/"lib",
       openmm_libs_base/"lib/plugins",
-      Formula["zlib"].opt_lib,
     ]
+
+    if OS.linux?
+      rpaths << Formula["gcc"].opt_lib
+      rpaths << Formula["opencl-icd-loader"].opt_lib
+      rpaths << Formula["zlib"].opt_lib
+    end
 
     inreplace "CMakeLists.txt",
       'CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}"',
-      "CMAKE_INSTALL_RPATH #{rpaths.join(";")}"
+      "CMAKE_INSTALL_RPATH #{rpaths.join(":")}"
 
     mkdir "build" do
       cmake_args = std_cmake_args + %W[

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -35,8 +35,8 @@ class Openstructure < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "libpq"
     depends_on "llvm"
-    depends_on "postgresql@15"
   end
 
   on_linux do

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -29,7 +29,6 @@ class Openstructure < Formula
   depends_on "llvm" if OS.mac?
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "postgresql@15" if OS.mac?
-  depends_on "pyqt@5"
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
@@ -83,6 +82,7 @@ class Openstructure < Formula
       scipy<2.0
       OpenMM
       parallelbar
+      PyQt5
     ]
     venv.pip_install_and_link resource("dockq")
 

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -48,8 +48,8 @@ class Openstructure < Formula
 
   patch do
     # Patch for Homebrew packaging (make openstructure src compatibile with boost@1.88 and fix CMake configs)
-    url "https://raw.githubusercontent.com/eunos-1128/openstructure/cf813460126174e2b42c50b81aac5552835dc8d0/homebrew.patch"
-    sha256 "74dda6db5d692fe81ae628be70394e4722000a39ffe3c0def545c24220163dd6"
+    url "https://raw.githubusercontent.com/eunos-1128/openstructure/1fbcfe506352da6f3c95a1752d3d54ef089fa12b/homebrew.patch"
+    sha256 "ce4f81a39087817023bdca23c124fb5e5f4800378aa0f374c89458dcbc39b5a1"
   end
 
   def python3

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -36,11 +36,6 @@ class Openstructure < Formula
 
   uses_from_macos "zlib"
 
-  conflicts_with "brewsci/bio/tmalign",
-    because: "both install `tmalign` binaries"
-  conflicts_with "brewsci/bio/usalign",
-    because: "both install `tmalign` binaries"
-
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
     sha256 "71ec068480215d86c561ee9216c21dfa1108d76eb38a3c54ddc27d28ef9c0b29"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -33,7 +33,6 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
-  depends_on "zlib" if OS.linux?
 
   uses_from_macos "zlib"
 
@@ -63,7 +62,9 @@ class Openstructure < Formula
       ENV.append "LDFLAGS", "-undefined dynamic_lookup"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
-      ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined -lstdc++"
+      ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined -lstdc++ -L#{Formula["zlib"].opt_lib}"
+      ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
     end
 
     # Install python packages using virtualenv pip
@@ -121,6 +122,7 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
+        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
         cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
       end
@@ -168,6 +170,7 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
+        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
         cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
       end

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -58,7 +58,7 @@ class Openstructure < Formula
   def install
     if OS.mac?
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup"
+      ENV.append "LDFLAGS", "-undefined dynamic_lookup -Wl,-export_dynamic"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -34,7 +34,8 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
-  depends_on "zlib"
+
+  uses_from_macos "zlib"
 
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
@@ -128,10 +129,13 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args << "-DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
-        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
+        zlib_args = %W[
+          -DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}
+          -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
+          -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
+          -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}
+        ]
+        cmake_args = zlib_args + cmake_args
       end
 
       system "cmake", "..", *cmake_args
@@ -177,10 +181,13 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args << "-DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
-        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
+        zlib_args = %W[
+          -DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}
+          -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
+          -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
+          -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}
+        ]
+        cmake_args = zlib_args + cmake_args
       end
 
       system "cmake", "..", *cmake_args

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -17,6 +17,7 @@ class Openstructure < Formula
   depends_on "brewsci/bio/clustal-w"
   depends_on "brewsci/bio/parasail"
   depends_on "brewsci/bio/sip@4"
+  depends_on "brewsci/bio/usalign"
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
   depends_on "fftw"
@@ -164,7 +165,7 @@ class Openstructure < Formula
         -DUSE_RPATH=ON
         -DOPTIMIZE=ON
         -DENABLE_PARASAIL=ON
-        -DCOMPILE_TMTOOLS=ON
+        -DCOMPILE_TMTOOLS=OFF
         -DENABLE_GFX=ON
         -DENABLE_GUI=ON
         -DENABLE_INFO=ON

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -70,10 +70,7 @@ class Openstructure < Formula
       ENV.prepend "LDFLAGS",
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
       ENV.prepend "LDFLAGS",
-        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
-      ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
-      ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"
-      ENV.delete "PKG_CONFIG_LIBDIR"
+        "-L#{Formula["gcc"].opt_lib/"gcc"/Formula["gcc"].version.major}"
     end
 
     # Install python packages using virtualenv pip

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -10,7 +10,6 @@ class Openstructure < Formula
 
   depends_on "cmake" => :build
   depends_on "glm" => :build
-  depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "boost-python3"
@@ -22,16 +21,11 @@ class Openstructure < Formula
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
   depends_on "fftw"
-  depends_on "gcc" if OS.linux?
   depends_on "glew"
   depends_on "glfw"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "llvm" if OS.mac?
-  depends_on "mesa-glu" if OS.linux?
   depends_on "openblas"
-  depends_on "opencl-icd-loader" if OS.linux?
-  depends_on "postgresql@15" if OS.mac?
   depends_on "pyqt@5"
   depends_on "python@3.13"
   depends_on "qt@5"
@@ -39,6 +33,19 @@ class Openstructure < Formula
   depends_on "sqlite"
 
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "llvm"
+    depends_on "postgresql@15"
+  end
+
+  on_linux do
+    depends_on "opencl-headers" => :build
+    depends_on "gcc"
+    depends_on "mesa"
+    depends_on "mesa-glu"
+    depends_on "opencl-icd-loader"
+  end
 
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -9,6 +9,7 @@ class Openstructure < Formula
   license "LGPL-3.0-or-later"
 
   depends_on "cmake" => :build
+  depends_on "glm" => :build
   depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
   depends_on "boost"
@@ -24,10 +25,10 @@ class Openstructure < Formula
   depends_on "gcc" if OS.linux?
   depends_on "glew"
   depends_on "glfw"
-  depends_on "glm"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "llvm" if OS.mac?
+  depends_on "mesa-glu" if OS.linux?
   depends_on "openblas"
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "postgresql@15" if OS.mac?

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -20,6 +20,7 @@ class Openstructure < Formula
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
   depends_on "fftw"
+  depends_on "gcc" if OS.linux?
   depends_on "glew"
   depends_on "glfw"
   depends_on "glm"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -125,6 +125,12 @@ class Openstructure < Formula
       ]
       if OS.linux?
         cmake_args += %W[
+          -DTIFF_ROOT=#{Formula["libtiff"].opt_prefix}
+          -DTIFF_LIBRARY=#{Formula["libtiff"].opt_lib}/libtiff.#{lib_ext}
+          -DTIFF_INCLUDE_DIR=#{Formula["libtiff"].opt_include}
+          -DPNG_ROOT=#{Formula["libpng"].opt_prefix}
+          -DPNG_LIBRARY=#{Formula["libpng"].opt_lib}/libpng.#{lib_ext}
+          -DPNG_PNG_INCLUDE_DIR=#{Formula["libpng"].opt_include}
           -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
           -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
           -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}
@@ -174,6 +180,12 @@ class Openstructure < Formula
       ]
       if OS.linux?
         cmake_args += %W[
+          -DTIFF_ROOT=#{Formula["libtiff"].opt_prefix}
+          -DTIFF_LIBRARY=#{Formula["libtiff"].opt_lib}/libtiff.#{lib_ext}
+          -DTIFF_INCLUDE_DIR=#{Formula["libtiff"].opt_include}
+          -DPNG_ROOT=#{Formula["libpng"].opt_prefix}
+          -DPNG_LIBRARY=#{Formula["libpng"].opt_lib}/libpng.#{lib_ext}
+          -DPNG_PNG_INCLUDE_DIR=#{Formula["libpng"].opt_include}
           -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
           -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
           -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -28,6 +28,7 @@ class Openstructure < Formula
   depends_on "libtiff"
   depends_on "llvm" if OS.mac?
   depends_on "opencl-icd-loader" if OS.linux?
+  depends_on "postgresql@15" if OS.mac?
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -70,7 +70,9 @@ class Openstructure < Formula
       ENV.prepend "LDFLAGS",
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
       ENV.prepend "LDFLAGS",
-        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
+        "-L#{Formula["python@3.13"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
+      ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib} -lz"
+      ENV.prepend "CFLAGS", "-I#{Formula["zlib"].opt_include} -I#{Formula["python@3.13"].opt_prefix}/include"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.delete "PKG_CONFIG_LIBDIR"
       ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -37,6 +37,10 @@ class Openstructure < Formula
 
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "zlib"
+  end
+
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
     sha256 "71ec068480215d86c561ee9216c21dfa1108d76eb38a3c54ddc27d28ef9c0b29"
@@ -72,10 +76,10 @@ class Openstructure < Formula
       ENV.prepend "LDFLAGS",
         "-L#{Formula["python@3.13"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
       ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib} -lz"
-      ENV.prepend "CFLAGS", "-I#{Formula["zlib"].opt_include} -I#{Formula["python@3.13"].opt_prefix}/include"
+      ENV.prepend "CFLAGS", "-I#{Formula["zlib"].opt_include} -I#{Formula["python@3.13"].opt_include}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
-      ENV.delete "PKG_CONFIG_LIBDIR"
       ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"
+      ENV.delete "PKG_CONFIG_LIBDIR"
     end
 
     # Install python packages using virtualenv pip

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -33,7 +33,6 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
-  depends_on "zlib" if OS.linux?
 
   uses_from_macos "zlib"
 
@@ -73,7 +72,7 @@ class Openstructure < Formula
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.delete "PKG_CONFIG_LIBDIR"
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
+      ENV["PKG_CONFIG_LIBDIR"] = Formula["zlib"].opt_lib/"pkgconfig"
     end
 
     # Install python packages using virtualenv pip

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -46,9 +46,9 @@ class Openstructure < Formula
   end
 
   patch do
-    # Patch for Homebrew packaging (make openstructure src compatibile with boost@1.88 and fix CMake settings)
-    url "https://raw.githubusercontent.com/eunos-1128/openstructure/59cc5f1f0a503484cca6debde40955851f7bab9e/homebrew.patch"
-    sha256 "63223a58e1b57a3cb20cbcf032d434f264053d5f1002641a2b24baa6b981c4ce"
+    # Patch for Homebrew packaging (make openstructure src compatibile with boost@1.88 and fix CMake configs)
+    url "https://raw.githubusercontent.com/eunos-1128/openstructure/05f1081c35408651ad72b7fdcbf6e5a44de5672e/homebrew.patch"
+    sha256 "8771bea089366502384f3d71bb060c1e4547ee2b9f454ba48ffef3ad56da748b"
   end
 
   def python3

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -29,6 +29,7 @@ class Openstructure < Formula
   depends_on "llvm" if OS.mac?
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "postgresql@15" if OS.mac?
+  depends_on "pyqt@5"
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
@@ -81,7 +82,6 @@ class Openstructure < Formula
       scipy<2.0
       OpenMM
       parallelbar
-      PyQt5
     ]
     venv.pip_install_and_link resource("dockq")
 

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -36,6 +36,11 @@ class Openstructure < Formula
 
   uses_from_macos "zlib"
 
+  conflicts_with "brewsci/bio/tmalign",
+    because: "both install `tmalign` binaries"
+  conflicts_with "brewsci/bio/usalign",
+    because: "both install `tmalign` binaries"
+
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
     sha256 "71ec068480215d86c561ee9216c21dfa1108d76eb38a3c54ddc27d28ef9c0b29"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -132,8 +132,6 @@ class Openstructure < Formula
         cmake_args = zlib_args + cmake_args
       end
 
-      puts cmake_args
-      exit
       system "cmake", "..", *cmake_args
       system "make", "VERBOSE=1"
 

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -56,12 +56,17 @@ class Openstructure < Formula
   end
 
   def install
+    py_ver = Language::Python.major_minor_version python3
+    py_ver_nodot = py_ver.to_s.delete(".")
+
     if OS.mac?
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup -Wl,-export_dynamic"
+      ENV.append "LDFLAGS",
+        "-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
-      ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"
+      ENV.append "LDFLAGS",
+        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -lpython#{py_ver} -L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
     end
@@ -85,9 +90,6 @@ class Openstructure < Formula
       PyQt5
     ]
     venv.pip_install_and_link resource("dockq")
-
-    py_ver = Language::Python.major_minor_version python3
-    py_ver_nodot = py_ver.to_s.delete(".")
     ENV.prepend_path "PATH", libexec/"bin"
     ENV.prepend_create_path "PYTHONPATH", venv.site_packages
     site_packages_path = Language::Python.site_packages python3

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -126,6 +126,8 @@ class Openstructure < Formula
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}
+        -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}
@@ -162,6 +164,8 @@ class Openstructure < Formula
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}
+        -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON
         -DPREFIX=#{prefix}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -9,6 +9,7 @@ class Openstructure < Formula
   license "LGPL-3.0-or-later"
 
   depends_on "cmake" => :build
+  depends_on "openblas" => :build
   depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
   depends_on "boost"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -105,7 +105,6 @@ class Openstructure < Formula
       openmm_libs_base/"lib",
       openmm_libs_base/"lib/plugins",
     ]
-
     if OS.linux?
       rpaths << Formula["gcc"].opt_lib
       rpaths << Formula["opencl-icd-loader"].opt_lib
@@ -113,8 +112,8 @@ class Openstructure < Formula
     end
 
     inreplace "CMakeLists.txt",
-      'CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}"',
-      "CMAKE_INSTALL_RPATH #{rpaths.join(":")}"
+      'SET(CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}")',
+      "SET(CMAKE_INSTALL_RPATH #{rpaths.join(";")})"
 
     mkdir "build" do
       cmake_args = std_cmake_args + %W[
@@ -128,6 +127,7 @@ class Openstructure < Formula
         -DENABLE_GUI=OFF
         -DENABLE_GFX=OFF
         -DENABLE_INFO=OFF
+        -DUSE_RPATH=ON
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -47,8 +47,8 @@ class Openstructure < Formula
 
   patch do
     # Patch for Homebrew packaging (make openstructure src compatibile with boost@1.88 and fix CMake configs)
-    url "https://raw.githubusercontent.com/eunos-1128/openstructure/05f1081c35408651ad72b7fdcbf6e5a44de5672e/homebrew.patch"
-    sha256 "8771bea089366502384f3d71bb060c1e4547ee2b9f454ba48ffef3ad56da748b"
+    url "https://raw.githubusercontent.com/eunos-1128/openstructure/cf813460126174e2b42c50b81aac5552835dc8d0/homebrew.patch"
+    sha256 "74dda6db5d692fe81ae628be70394e4722000a39ffe3c0def545c24220163dd6"
   end
 
   def python3
@@ -132,8 +132,6 @@ class Openstructure < Formula
         -DENABLE_INFO=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
-      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
-      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
@@ -185,8 +183,6 @@ class Openstructure < Formula
         -DUSE_DOUBLE_PRECISION=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
-      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
-      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -35,7 +35,7 @@ class Openstructure < Formula
 
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
-    sha256 "9d7c273609b1d5d1a7247e20c882a318f5dd199860e8e7dcc1374006f51f3c0c"
+    sha256 "71ec068480215d86c561ee9216c21dfa1108d76eb38a3c54ddc27d28ef9c0b29"
   end
 
   resource "dockq" do

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -58,7 +58,7 @@ class Openstructure < Formula
   def install
     if OS.mac?
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup -Wl,--export-dynamic"
+      ENV.append "LDFLAGS", "-undefined dynamic_lookup"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -15,6 +15,7 @@ class Openstructure < Formula
   depends_on "boost-python3"
   depends_on "brewsci/bio/clustal-w"
   depends_on "brewsci/bio/parasail"
+  depends_on "brewsci/bio/sip@4"
   depends_on "brewsci/bio/usalign"
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
@@ -28,6 +29,7 @@ class Openstructure < Formula
   depends_on "llvm" if OS.mac?
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "python@3.13"
+  depends_on "qt@5"
   depends_on "sqlite"
   depends_on "zlib" if OS.linux?
 
@@ -78,6 +80,7 @@ class Openstructure < Formula
       scipy<2.0
       OpenMM
       parallelbar
+      PyQt5
     ]
     venv.pip_install_and_link resource("dockq")
 
@@ -156,10 +159,10 @@ class Openstructure < Formula
         -DOPTIMIZE=ON
         -DENABLE_PARASAIL=ON
         -DCOMPILE_TMTOOLS=OFF
-        -DENABLE_GFX=OFF
-        -DENABLE_GUI=OFF
-        -DENABLE_INFO=OFF
-        -DUSE_SHADER=OFF
+        -DENABLE_GFX=ON
+        -DENABLE_GUI=ON
+        -DENABLE_INFO=ON
+        -DUSE_SHADER=ON
         -DUSE_DOUBLE_PRECISION=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -124,12 +124,11 @@ class Openstructure < Formula
         -DUSE_RPATH=ON
       ]
       if OS.linux?
-        zlib_args = %W[
+        cmake_args += %W[
           -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
           -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
           -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}
         ]
-        cmake_args = zlib_args + cmake_args
       end
 
       system "cmake", "..", *cmake_args
@@ -174,12 +173,11 @@ class Openstructure < Formula
         -DUSE_DOUBLE_PRECISION=OFF
       ]
       if OS.linux?
-        zlib_args = %W[
+        cmake_args += %W[
           -DZLIB_ROOT=#{Formula["zlib"].opt_prefix}
           -DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}
           -DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}
         ]
-        cmake_args = zlib_args + cmake_args
       end
 
       system "cmake", "..", *cmake_args

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -58,10 +58,10 @@ class Openstructure < Formula
   def install
     if OS.mac?
       ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup"
+      ENV.append "LDFLAGS", "-undefined dynamic_lookup -Wl,--export-dynamic"
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
-      ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined -lstdc++ -L#{Formula["zlib"].opt_lib}"
+      ENV.append "LDFLAGS", "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
     end

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -101,7 +101,7 @@ class Openstructure < Formula
     openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
     rpaths = [
-      "$ORIGIN/../${LIB_DIR}",
+      lib,
       openmm_libs_base/"lib",
       openmm_libs_base/"lib/plugins",
     ]

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -74,9 +74,7 @@ class Openstructure < Formula
       ENV.prepend "LDFLAGS",
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
       ENV.prepend "LDFLAGS",
-        "-L#{Formula["python@3.13"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
-      ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib}"
-      ENV.prepend "CFLAGS", "-I#{Formula["zlib"].opt_include} -I#{Formula["python@3.13"].opt_include}"
+        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"
       ENV.delete "PKG_CONFIG_LIBDIR"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -121,7 +121,6 @@ class Openstructure < Formula
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}
-        -DPython_FIND_FRAMEWORK=NEVER
         -DENABLE_GUI=OFF
         -DENABLE_GFX=OFF
         -DENABLE_INFO=OFF
@@ -163,7 +162,6 @@ class Openstructure < Formula
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}
-        -DPython_FIND_FRAMEWORK=NEVER
         -DCOMPOUND_LIB=#{buildpath}/build/compounds.chemlib
         -DPARASAIL_INCLUDE_DIR=#{Formula["brewsci/bio/parasail"].opt_include}
         -DPARASAIL_LIBRARY=#{Formula["brewsci/bio/parasail"].opt_lib}/libparasail.#{lib_ext}

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -33,6 +33,7 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
+  depends_on "zlib" if OS.linux?
 
   uses_from_macos "zlib"
 
@@ -71,6 +72,9 @@ class Openstructure < Formula
       ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
+      ENV.prepend_path "LD_LIBRARY_PATH", Formula["zlib"].opt_lib
+      ENV.prepend_path "LD_LIBRARY_PATH", Formula["gcc"].opt_lib
+      ENV.prepend_path "LD_LIBRARY_PATH", Formula["opencl-icd-loader"].opt_lib
     end
 
     # Install python packages using virtualenv pip
@@ -99,6 +103,8 @@ class Openstructure < Formula
     lib_ext = OS.mac? ? "dylib" : "so"
 
     openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
+    ENV.prepend_path "LD_LIBRARY_PATH", openmm_libs_base/"lib"
+    ENV.prepend_path "LD_LIBRARY_PATH", openmm_libs_base/"lib/plugins"
 
     rpaths = [
       lib,

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -131,6 +131,7 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
+        cmake_args << "-DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
         cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
@@ -179,6 +180,7 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
+        cmake_args << "-DCMAKE_PREFIX_PATH=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
         cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -29,6 +29,7 @@ class Openstructure < Formula
   depends_on "llvm" if OS.mac?
   depends_on "opencl-icd-loader" if OS.linux?
   depends_on "postgresql@15" if OS.mac?
+  depends_on "pyqt@5"
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
@@ -87,7 +88,6 @@ class Openstructure < Formula
       scipy<2.0
       OpenMM
       parallelbar
-      PyQt5
     ]
     venv.pip_install_and_link resource("dockq")
     ENV.prepend_path "PATH", libexec/"bin"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -106,25 +106,19 @@ class Openstructure < Formula
       openmm_libs_base/"lib/plugins",
     ]
     if OS.linux?
-      rpaths += [
-        Formula["gcc"].opt_lib,
-        Formula["opencl-icd-loader"].opt_lib,
-        Formula["zlib"].opt_lib,
-      ]
+      rpaths << Formula["gcc"].opt_lib
+      rpaths << Formula["opencl-icd-loader"].opt_lib
+      rpaths << Formula["zlib"].opt_lib
     end
 
     inreplace "CMakeLists.txt",
       'SET(CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}")',
       "SET(CMAKE_INSTALL_RPATH #{rpaths.join(";")})"
 
-    ldflags = rpaths.map { |p| "-Wl,-rpath,#{p}" }.join(" ")
     mkdir "build" do
       cmake_args = std_cmake_args + %W[
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
-        -DCMAKE_EXE_LINKER_FLAGS=#{ldflags}
-        -DCMAKE_SHARED_LINKER_FLAGS=#{ldflags}
-        -DCMAKE_MODULE_LINKER_FLAGS=#{ldflags}
         -DCMAKE_CXX_STANDARD=17
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
@@ -137,11 +131,9 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args += [
-          "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}",
-          "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}",
-          "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}",
-        ]
+        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
+        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
+        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
       end
 
       system "cmake", "..", *cmake_args
@@ -162,9 +154,6 @@ class Openstructure < Formula
       cmake_args = std_cmake_args + %W[
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
-        -DCMAKE_EXE_LINKER_FLAGS=#{ldflags}
-        -DCMAKE_SHARED_LINKER_FLAGS=#{ldflags}
-        -DCMAKE_MODULE_LINKER_FLAGS=#{ldflags}
         -DCMAKE_CXX_STANDARD=17
         -DPREFIX=#{prefix}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
@@ -190,11 +179,9 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args += [
-          "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}",
-          "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}",
-          "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}",
-        ]
+        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
+        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
+        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
       end
 
       system "cmake", "..", *cmake_args

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -96,12 +96,6 @@ class Openstructure < Formula
     (prefix/site_packages_path/"homebrew-openstructure.pth").write venv.site_packages
 
     lib_ext = OS.mac? ? "dylib" : "so"
-    py_lib = "libpython#{py_ver}.#{lib_ext}"
-    py_lib_path = if OS.mac?
-      Formula["python@#{py_ver}"].opt_frameworks/"Python.framework/Versions/#{py_ver}/lib/#{py_lib}"
-    elsif OS.linux?
-      Formula["python@#{py_ver}"].opt_lib/py_lib
-    end
 
     openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
@@ -120,9 +114,6 @@ class Openstructure < Formula
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
-        -DPython_EXECUTABLE=#{libexec}/bin/python3
-        -DPython_ROOT_DIR=#{libexec}
-        -DPython_LIBRARY=#{py_lib_path}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}
@@ -158,9 +149,6 @@ class Openstructure < Formula
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
         -DPREFIX=#{prefix}
-        -DPython_EXECUTABLE=#{libexec}/bin/python3
-        -DPython_ROOT_DIR=#{libexec}
-        -DPython_LIBRARY=#{py_lib_path}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -123,8 +123,8 @@ class Openstructure < Formula
         -DENABLE_INFO=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
-      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
-      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
+      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
+      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
@@ -173,8 +173,8 @@ class Openstructure < Formula
         -DUSE_DOUBLE_PRECISION=OFF
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
-      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
-      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic -lpython#{py_ver}"
+      cmake_args << "-DCMAKE_SHARED_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
+      cmake_args << "-DCMAKE_EXE_LINKER_FLAGS=-undefined dynamic_lookup -Wl,-export_dynamic"
       if OS.linux?
         cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
         cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -93,7 +93,6 @@ class Openstructure < Formula
     venv.pip_install_and_link resource("dockq")
 
     lib_ext = OS.mac? ? "dylib" : "so"
-    openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
     mkdir "build" do
       cmake_args = std_cmake_args + %W[
@@ -137,9 +136,9 @@ class Openstructure < Formula
         -DCOMPOUND_LIB=#{buildpath}/build/compounds.chemlib
         -DPARASAIL_INCLUDE_DIR=#{Formula["brewsci/bio/parasail"].opt_include}
         -DPARASAIL_LIBRARY=#{Formula["brewsci/bio/parasail"].opt_lib}/libparasail.#{lib_ext}
-        -DOPEN_MM_LIBRARY=#{openmm_libs_base}/lib/libOpenMM.#{lib_ext}
-        -DOPEN_MM_INCLUDE_DIR=#{openmm_libs_base}/include
-        -DOPEN_MM_PLUGIN_DIR=#{openmm_libs_base}/lib/plugins
+        -DOPEN_MM_LIBRARY=#{Formula["brewsci/bio/openmm@7"].opt_lib}/libOpenMM.#{lib_ext}
+        -DOPEN_MM_INCLUDE_DIR=#{Formula["brewsci/bio/openmm@7"].opt_include}
+        -DOPEN_MM_PLUGIN_DIR=#{Formula["brewsci/bio/openmm@7"].opt_lib}/plugins
         -DENABLE_MM=ON
         -DUSE_RPATH=ON
         -DOPTIMIZE=ON

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -11,7 +11,6 @@ class Openstructure < Formula
   depends_on "cmake" => :build
   depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
-  depends_on "zlib" => :build if OS.linux?
   depends_on "boost"
   depends_on "boost-python3"
   depends_on "brewsci/bio/clustal-w"
@@ -21,7 +20,6 @@ class Openstructure < Formula
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
   depends_on "fftw"
-  depends_on "gcc"
   depends_on "glew"
   depends_on "glfw"
   depends_on "glm"
@@ -34,6 +32,7 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
+  depends_on "zlib" if OS.linux?
 
   uses_from_macos "zlib"
 
@@ -105,6 +104,7 @@ class Openstructure < Formula
       lib,
       openmm_libs_base/"lib",
       openmm_libs_base/"lib/plugins",
+      Formula["zlib"].opt_lib,
     ]
 
     inreplace "CMakeLists.txt",

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -9,6 +9,7 @@ class Openstructure < Formula
   license "LGPL-3.0-or-later"
 
   depends_on "cmake" => :build
+  depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "boost-python3"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -25,6 +25,7 @@ class Openstructure < Formula
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "llvm" if OS.mac?
+  depends_on "opencl-icd-loader" if OS.linux?
   depends_on "python@3.13"
   depends_on "sqlite"
   depends_on "zlib" if OS.linux?

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -11,6 +11,7 @@ class Openstructure < Formula
   depends_on "cmake" => :build
   depends_on "opencl-headers" => :build if OS.linux?
   depends_on "pkg-config" => :build
+  depends_on "zlib" => :build if OS.linux?
   depends_on "boost"
   depends_on "boost-python3"
   depends_on "brewsci/bio/clustal-w"
@@ -66,7 +67,8 @@ class Openstructure < Formula
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.append "LDFLAGS",
-        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++ -L#{Formula["zlib"].opt_lib}"
+        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
+      ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["zlib"].opt_lib}/pkgconfig"
     end

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -68,9 +68,12 @@ class Openstructure < Formula
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.prepend "LDFLAGS",
-        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
+        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
       ENV.prepend "LDFLAGS",
-        "-L#{Formula["gcc"].opt_lib/"gcc"/Formula["gcc"].version.major}"
+        "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
+      ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
+      ENV.delete "PKG_CONFIG_LIBDIR"
+      ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"
     end
 
     # Install python packages using virtualenv pip

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -87,13 +87,12 @@ class Openstructure < Formula
       networkx<3.0
       numpy<2.0
       pandas<2.3
-      OpenMM<9.0
       parallelbar<3.0
     ]
     venv.pip_install_and_link resource("dockq")
+    system(libexec/"bin/python", "-m", "pip", "install", "OpenMM<9.0") if OS.mac?
 
     lib_ext = OS.mac? ? "dylib" : "so"
-    openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
     mkdir "build" do
       cmake_args = std_cmake_args + %W[
@@ -150,6 +149,7 @@ class Openstructure < Formula
 
       # Enable OpenMM support only on macOS
       if OS.mac?
+        openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
         cmake_args +=[
           "-DENABLE_MM=ON",
           "-DOPEN_MM_LIBRARY=#{openmm_libs_base}/lib/libOpenMM.#{lib_ext}",

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -96,6 +96,12 @@ class Openstructure < Formula
     (prefix/site_packages_path/"homebrew-openstructure.pth").write venv.site_packages
 
     lib_ext = OS.mac? ? "dylib" : "so"
+    py_lib = "libpython#{py_ver}.#{lib_ext}"
+    py_lib_path = if OS.mac?
+      Formula["python@#{py_ver}"].opt_frameworks/"Python.framework/Versions/#{py_ver}/lib/#{py_lib}"
+    elsif OS.linux?
+      Formula["python@#{py_ver}"].opt_lib/py_lib
+    end
 
     openmm_libs_base = libexec/"lib/python#{py_ver}/site-packages/OpenMM.libs"
 
@@ -114,6 +120,9 @@ class Openstructure < Formula
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
+        -DPython_EXECUTABLE=#{libexec}/bin/python3
+        -DPython_ROOT_DIR=#{libexec}
+        -DPython_LIBRARY=#{py_lib_path}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}
@@ -151,6 +160,9 @@ class Openstructure < Formula
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
         -DCMAKE_CXX_STANDARD=17
         -DPREFIX=#{prefix}
+        -DPython_EXECUTABLE=#{libexec}/bin/python3
+        -DPython_ROOT_DIR=#{libexec}
+        -DPython_LIBRARY=#{py_lib_path}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
         -DBOOST_PYTHON_LIBRARIES=#{Formula["boost-python3"].opt_lib}/libboost_python#{py_ver_nodot}.#{lib_ext}

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -178,6 +178,8 @@ class Openstructure < Formula
   def caveats
     <<~EOS
       You may need to install the following packages to use certain python bindings:
+      (Refer to https://openstructure.org/docs/2.9.2/bindings/bindings/)
+
         - blast
         - brewsci/bio/dssp
         - brewsci/bio/hh-suite

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -86,13 +86,13 @@ class Openstructure < Formula
       wheel
     ]
     system libexec/"bin/python", "-m", "pip", "install", *%w[
-      biopython
+      biopython<2.0
       networkx<3.0
-      numpy<2.2
+      numpy<2.0
       pandas<2.3
       scipy<2.0
-      OpenMM
-      parallelbar
+      OpenMM<9.0
+      parallelbar<3.0
     ]
     venv.pip_install_and_link resource("dockq")
 

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -75,7 +75,7 @@ class Openstructure < Formula
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
       ENV.prepend "LDFLAGS",
         "-L#{Formula["python@3.13"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
-      ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib} -lz"
+      ENV.prepend "LDFLAGS", "-L#{Formula["zlib"].opt_lib}"
       ENV.prepend "CFLAGS", "-I#{Formula["zlib"].opt_include} -I#{Formula["python@3.13"].opt_include}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -16,7 +16,6 @@ class Openstructure < Formula
   depends_on "brewsci/bio/clustal-w"
   depends_on "brewsci/bio/parasail"
   depends_on "brewsci/bio/sip@4"
-  depends_on "brewsci/bio/usalign"
   depends_on "brewsci/bio/voronota"
   depends_on "eigen"
   depends_on "fftw"
@@ -163,7 +162,7 @@ class Openstructure < Formula
         -DUSE_RPATH=ON
         -DOPTIMIZE=ON
         -DENABLE_PARASAIL=ON
-        -DCOMPILE_TMTOOLS=OFF
+        -DCOMPILE_TMTOOLS=ON
         -DENABLE_GFX=ON
         -DENABLE_GUI=ON
         -DENABLE_INFO=ON

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -91,7 +91,7 @@ class Openstructure < Formula
     system libexec/"bin/python", "-m", "pip", "install", *%w[
       biopython
       networkx<3.0
-      numpy<2.0
+      numpy<2.2
       pandas<2.3
       scipy<2.0
       OpenMM

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -106,19 +106,25 @@ class Openstructure < Formula
       openmm_libs_base/"lib/plugins",
     ]
     if OS.linux?
-      rpaths << Formula["gcc"].opt_lib
-      rpaths << Formula["opencl-icd-loader"].opt_lib
-      rpaths << Formula["zlib"].opt_lib
+      rpaths += [
+        Formula["gcc"].opt_lib,
+        Formula["opencl-icd-loader"].opt_lib,
+        Formula["zlib"].opt_lib,
+      ]
     end
 
     inreplace "CMakeLists.txt",
       'SET(CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}")',
       "SET(CMAKE_INSTALL_RPATH #{rpaths.join(";")})"
 
+    ldflags = rpaths.map { |p| "-Wl,-rpath,#{p}" }.join(" ")
     mkdir "build" do
       cmake_args = std_cmake_args + %W[
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
+        -DCMAKE_EXE_LINKER_FLAGS=#{ldflags}
+        -DCMAKE_SHARED_LINKER_FLAGS=#{ldflags}
+        -DCMAKE_MODULE_LINKER_FLAGS=#{ldflags}
         -DCMAKE_CXX_STANDARD=17
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
         -DBoost_INCLUDE_DIRS=#{Formula["boost"].opt_include}
@@ -131,9 +137,11 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
-        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
+        cmake_args += [
+          "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}",
+          "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}",
+          "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}",
+        ]
       end
 
       system "cmake", "..", *cmake_args
@@ -154,6 +162,9 @@ class Openstructure < Formula
       cmake_args = std_cmake_args + %W[
         -DCMAKE_CXX_COMPILER=#{ENV["CXX"]}
         -DCXX_FLAGS=#{ENV["CXXFLAGS"]}
+        -DCMAKE_EXE_LINKER_FLAGS=#{ldflags}
+        -DCMAKE_SHARED_LINKER_FLAGS=#{ldflags}
+        -DCMAKE_MODULE_LINKER_FLAGS=#{ldflags}
         -DCMAKE_CXX_STANDARD=17
         -DPREFIX=#{prefix}
         -DBOOST_ROOT=#{Formula["boost"].opt_prefix}
@@ -179,9 +190,11 @@ class Openstructure < Formula
         -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
-        cmake_args << "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}"
-        cmake_args << "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}"
-        cmake_args << "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}"
+        cmake_args += [
+          "-DZLIB_ROOT=#{Formula["zlib"].opt_prefix}",
+          "-DZLIB_LIBRARY=#{Formula["zlib"].opt_lib}/libz.#{lib_ext}",
+          "-DZLIB_INCLUDE_DIR=#{Formula["zlib"].opt_include}",
+        ]
       end
 
       system "cmake", "..", *cmake_args

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -34,8 +34,7 @@ class Openstructure < Formula
   depends_on "python@3.13"
   depends_on "qt@5"
   depends_on "sqlite"
-
-  uses_from_macos "zlib"
+  depends_on "zlib"
 
   resource "components-cif" do
     url "https://files.wwpdb.org/pub/pdb/data/monomers/components.cif.gz"
@@ -68,12 +67,12 @@ class Openstructure < Formula
     elsif OS.linux?
       ENV["CXX"] = Formula["gcc"].opt_bin/"g++-#{Formula["gcc"].version.major}"
       ENV.prepend "LDFLAGS",
-        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
-      ENV.prepend "LDFLAGS",
         "-Wl,--allow-shlib-undefined,--export-dynamic -lstdc++"
+      ENV.prepend "LDFLAGS",
+        "-L#{Formula["zlib"].opt_lib} -L#{Formula["gcc"].opt_lib} -L#{Formula["opencl-icd-loader"].opt_lib}"
       ENV.prepend "CPPFLAGS", "-I#{Formula["zlib"].opt_include}"
       ENV.delete "PKG_CONFIG_LIBDIR"
-      ENV["PKG_CONFIG_LIBDIR"] = Formula["zlib"].opt_lib/"pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib"].opt_lib/"pkgconfig"
     end
 
     # Install python packages using virtualenv pip
@@ -111,7 +110,7 @@ class Openstructure < Formula
 
     inreplace "CMakeLists.txt",
       'SET(CMAKE_INSTALL_RPATH "$ORIGIN/../${LIB_DIR}")',
-      "SET(CMAKE_INSTALL_RPATH #{rpaths.join(" ")})"
+      "SET(CMAKE_INSTALL_RPATH #{rpaths.join(";")})"
 
     mkdir "build" do
       cmake_args = std_cmake_args + %W[

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -93,10 +93,12 @@ class Openstructure < Formula
       networkx<3.0
       numpy<2.0
       pandas<2.3
-      scipy<2.0
       OpenMM<9.0
       parallelbar<3.0
     ]
+    # Build scipy from source to prevent from zlib being linked to system zlib
+    system libexec/"bin/python", "-m", "pip", "install", "--no-binary", ":all:", "scipy<2.0"
+
     venv.pip_install_and_link resource("dockq")
 
     lib_ext = OS.mac? ? "dylib" : "so"

--- a/Formula/openstructure.rb
+++ b/Formula/openstructure.rb
@@ -125,7 +125,6 @@ class Openstructure < Formula
         -DENABLE_GFX=OFF
         -DENABLE_INFO=OFF
         -DUSE_RPATH=ON
-        -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
         zlib_args = %W[
@@ -178,7 +177,6 @@ class Openstructure < Formula
         -DENABLE_INFO=ON
         -DUSE_SHADER=ON
         -DUSE_DOUBLE_PRECISION=OFF
-        -DCMAKE_VERBOSE_MAKEFILE=ON
       ]
       if OS.linux?
         zlib_args = %W[


### PR DESCRIPTION
This pull request updates the dependencies for the `Openstructure` formula to align with platform-specific requirements.

Dependency updates:

* [`Formula/openstructure.rb`](diffhunk://#diff-bec696567eb9cc30ed32151e2c39b1adddd4ce6d25c23c588e9e89e6671bb997R46-L47): Replaced `postgresql@15` with `libpq` as a dependency for macOS to streamline compatibility and reduce redundancy.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
