### PR TITLE
dssp: Enable Python bindings

### DIFF
--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -75,6 +75,8 @@ class Dssp < Formula
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
                     "-DPython_ROOT_DIR=#{libexec}",
+                    "-DPython_EXECUTABLE=#{libexec/"bin/python3.13"}",
+                    "-DPython_INCLUDE_DIR=#{libexec/"include/python3.13"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -1,4 +1,6 @@
 class Dssp < Formula
+  include Language::Python::Virtualenv
+
   # cite Touw_2015: "https://doi.org/10.1093/nar/gku1028"
   # cite Kabsch_1983: "https://doi.org/10.1002/bip.360221211"
   desc "Assign secondary structure to proteins"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -40,6 +40,10 @@ class Dssp < Formula
     sha256 "c6a2e4716f843bd608c06cfa4b6a369a56a6021ae16e5f876237b8a73d0dcb5e"
   end
 
+  def python3
+    "python3.13"
+  end
+
   def install
     resource("libcifpp").stage do
       # libcifpp should be installed in 'prefix' directory since the path of dic files are always required.
@@ -54,6 +58,9 @@ class Dssp < Formula
       system "cmake", "--build", "build"
       system "cmake", "--install", "build"
     end
+
+    site_packages_path = Language::Python.site_packages python3
+    mkdir_p site_packages_path
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -55,7 +55,7 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    (Formula["python@3.13"].opt_lib/"python3.13/site-packages").mkpath
+    ENV.prepend_create_path "PYTHONPATH", lib/"python3.13/site-packages"
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
@@ -64,7 +64,7 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_SITELIB=#{Formula["python@3.13"].opt_lib/"python3.13/site-packages"}",
+                    "-DPython_SITELIB=#{lib/"python3.13/site-packages"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -60,7 +60,8 @@ class Dssp < Formula
     end
 
     site_packages_path = Language::Python.site_packages python3
-    site_packages_path.mkpath
+    mkdir_p site_packages_path
+    chmod 0755, site_packages_path
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -55,7 +55,7 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    site_packages_path = (Formula["python@3.13"].opt_lib/"python3.13/site-packages").mkpath
+    (Formula["python@3.13"].opt_lib/"python3.13/site-packages").mkpath
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
@@ -64,7 +64,7 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_SITELIB=#{site_packages_path}",
+                    "-DPython_SITELIB=#{Formula["python@3.13"].opt_lib/"python3.13/site-packages"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -19,9 +19,7 @@ class Dssp < Formula
   depends_on "cmake" => :build
   depends_on "eigen" => :build
   depends_on "boost"
-  depends_on "boost-python3"
   depends_on "icu4c"
-  depends_on "python@3.13"
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
@@ -55,16 +53,12 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    inreplace "python-module/CMakeLists.txt", 'SUFFIX ".so"', 'SUFFIX ".dylib"' if OS.mac?
-
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
-                    "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_ROOT_DIR=#{Formula["python@3.13"].opt_prefix}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -40,10 +40,6 @@ class Dssp < Formula
     sha256 "c6a2e4716f843bd608c06cfa4b6a369a56a6021ae16e5f876237b8a73d0dcb5e"
   end
 
-  def python3
-    "python3.13"
-  end
-
   def install
     resource("libcifpp").stage do
       # libcifpp should be installed in 'prefix' directory since the path of dic files are always required.
@@ -59,8 +55,6 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    site_packages_path = Language::Python.site_packages python3
-
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
@@ -68,7 +62,7 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPYTHON_SITE_PACKAGES=#{site_packages_path}",
+                    "-DPython_SITELIB=#{Formula["python@3.13"].opt_lib/"python3.13/site-packages"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
@@ -81,6 +75,6 @@ class Dssp < Formula
     assert_match "CELLULAR RETINOIC ACID BINDING PROTEIN TYPE II", (testpath/"test.dssp").read
 
     # Check if the Python module can be imported
-    system python3, "-c", "import mkdssp"
+    system "python3", "-c", "import mkdssp"
   end
 end

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -26,13 +26,13 @@ class Dssp < Formula
   uses_from_macos "zlib"
 
   resource "libcifpp" do
-    url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v7.0.7.tar.gz"
-    sha256 "0e88805b4704d4a899aeee6df5aaace1d6b47d8ccb3a3f39b35bc5a3997c09ac"
+    url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v8.0.1.tar.gz"
+    sha256 "53f0ff205711428dcabf9451b23804091539303cea9d2f54554199144ca0fc4e"
   end
 
   resource "libmcfp" do
-    url "https://github.com/mhekkel/libmcfp/archive/refs/tags/v1.3.3.tar.gz"
-    sha256 "d35e83e660c3cb443d20246fea39e78d2a11faebe3205ab838614f0280c308d0"
+    url "https://github.com/mhekkel/libmcfp/archive/refs/tags/v1.4.2.tar.gz"
+    sha256 "dcdf3e81601081b2a9e2f2e1bb1ee2a8545190358d5d9bec9158ad70f5ca355e"
   end
 
   resource "testdata" do

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -60,7 +60,7 @@ class Dssp < Formula
     end
 
     site_packages_path = Language::Python.site_packages python3
-    mkdir_p site_packages_path
+    site_packages_path.mkpath
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -55,6 +55,8 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
+    inreplace "python-module/CMakeLists.txt", 'SUFFIX ".so"', 'SUFFIX ".dylib"' if OS.mac?
+
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -57,7 +57,7 @@ class Dssp < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
-                    "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/libmcfp"}",
+                    "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -40,6 +40,10 @@ class Dssp < Formula
     sha256 "c6a2e4716f843bd608c06cfa4b6a369a56a6021ae16e5f876237b8a73d0dcb5e"
   end
 
+  def python3
+    "python3.13"
+  end
+
   def install
     resource("libcifpp").stage do
       # libcifpp should be installed in 'prefix' directory since the path of dic files are always required.
@@ -55,6 +59,12 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
+    venv = virtualenv_create libexec, which(python3)
+    ENV.prepend_path "PATH", libexec/"bin"
+    ENV.prepend_create_path "PYTHONPATH", venv.site_packages
+    site_packages_path = Language::Python.site_packages python3
+    (prefix/site_packages_path/"homebrew-dssp.pth").write venv.site_packages
+
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
@@ -63,8 +73,6 @@ class Dssp < Formula
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
                     "-DPython_ROOT_DIR=#{libexec}",
-                    "-DPython_EXECUTABLE=#{libexec/"bin/python3.13"}",
-                    "-DPython_INCLUDE_DIR=#{libexec/"include/python3.13"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
@@ -77,6 +85,6 @@ class Dssp < Formula
     assert_match "CELLULAR RETINOIC ACID BINDING PROTEIN TYPE II", (testpath/"test.dssp").read
 
     # Check if the Python module can be imported
-    system "python3", "-c", "import mkdssp"
+    system python3, "-c", "import mkdssp"
   end
 end

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -61,6 +61,7 @@ class Dssp < Formula
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
+                    "-DBUILD_PYTHON_MODULE=ON",
                     "-DPython_ROOT_DIR=#{Formula["python@3.13"].opt_prefix}",
                     *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -55,8 +55,6 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    ENV.prepend_create_path "PYTHONPATH", lib/"python3.13/site-packages"
-
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
@@ -64,7 +62,9 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_SITELIB=#{lib/"python3.13/site-packages"}",
+                    "-DPython_ROOT_DIR=#{libexec}",
+                    "-DPython_EXECUTABLE=#{libexec/"bin/python3.13"}",
+                    "-DPython_INCLUDE_DIR=#{libexec/"include/python3.13"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -63,6 +63,9 @@ class Dssp < Formula
 
     if OS.mac?
       inreplace "python-module/CMakeLists.txt",
+        "target_link_libraries(mkdssp_module dssp::dssp Boost::python ${Python_LIBRARIES})",
+        "target_link_libraries(mkdssp_module dssp::dssp Boost::python)"
+      inreplace "python-module/CMakeLists.txt",
         'LIBRARY DESTINATION "${Python_SITELIB}"',
         "LIBRARY DESTINATION #{lib}/python3.13/site-packages"
     end

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -47,9 +47,7 @@ class Dssp < Formula
   end
 
   def install
-    if OS.mac?
-      ENV.prepend "LDFLAGS", "-undefined dynamic_lookup"
-    end
+    ENV.prepend "LDFLAGS", "-undefined dynamic_lookup" if OS.mac?
 
     resource("libcifpp").stage do
       # libcifpp should be installed in 'prefix' directory since the path of dic files are always required.

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -1,6 +1,4 @@
 class Dssp < Formula
-  include Language::Python::Virtualenv
-
   # cite Touw_2015: "https://doi.org/10.1093/nar/gku1028"
   # cite Kabsch_1983: "https://doi.org/10.1002/bip.360221211"
   desc "Assign secondary structure to proteins"
@@ -63,12 +61,11 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
-    venv = virtualenv_create libexec, which(python3)
-    ENV.prepend_path "PATH", libexec/"bin"
-    ENV.prepend_create_path "PYTHONPATH", venv.site_packages
-    site_packages_path = Language::Python.site_packages python3
-    (prefix/site_packages_path/"homebrew-dssp.pth").write venv.site_packages
-    shared_lib_ext = OS.mac? ? "dylib" : "so"
+    if OS.mac?
+      inreplace "python-module/CMakeLists.txt",
+        'LIBRARY DESTINATION "${Python_SITELIB}"',
+        "LIBRARY DESTINATION #{lib}/python3.13/site-packages"
+    end
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
@@ -77,9 +74,6 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_ROOT_DIR=#{libexec}",
-                    "-DPython_EXECUTABLE=#{libexec/"bin/python3.13"}",
-                    "-DPython_INCLUDE_DIR=#{libexec/"include/python3.13"}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -3,8 +3,8 @@ class Dssp < Formula
   # cite Kabsch_1983: "https://doi.org/10.1002/bip.360221211"
   desc "Assign secondary structure to proteins"
   homepage "https://github.com/PDB-REDO/dssp"
-  url "https://github.com/PDB-REDO/dssp/archive/refs/tags/v4.4.10.tar.gz"
-  sha256 "b535d0410a79d612a2abea308d13d0ae2645bb925b13a86e5bb53c38b0fac723"
+  url "https://github.com/PDB-REDO/dssp/archive/refs/tags/v4.5.3.tar.gz"
+  sha256 "8dd92fdf2a252a170c8a811e3adb752e0f2860318ecb2b6ed5e4fd1d2b5ce5e6"
   license "BSD-2-Clause"
   head "https://github.com/PDB-REDO/dssp.git", branch: "trunk"
 
@@ -19,7 +19,9 @@ class Dssp < Formula
   depends_on "cmake" => :build
   depends_on "eigen" => :build
   depends_on "boost"
+  depends_on "boost-python3"
   depends_on "icu4c"
+  depends_on "python@3.13"
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
@@ -55,8 +57,11 @@ class Dssp < Formula
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
-                    "-Dlibmcfp_DIR=#{prefix/"libmcfp/lib/cmake/libmcfp"}",
+                    "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/libmcfp"}",
                     "-DCMAKE_BUILD_TYPE=Release",
+                    "-DCMAKE_CXX_STANDARD=20",
+                    "-DINSTALL_LIBRARY=ON",
+                    "-DPython_ROOT_DIR=#{Formula["python@3.13"].opt_prefix}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -55,6 +55,8 @@ class Dssp < Formula
       system "cmake", "--install", "build"
     end
 
+    site_packages_path = (Formula["python@3.13"].opt_lib/"python3.13/site-packages").mkpath
+
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
                     "-Dmcfp_DIR=#{prefix/"libmcfp/lib/cmake/mcfp"}",
@@ -62,7 +64,7 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DPython_SITELIB=#{Formula["python@3.13"].opt_lib/"python3.13/site-packages"}",
+                    "-DPython_SITELIB=#{site_packages_path}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -79,5 +79,8 @@ class Dssp < Formula
     cp Dir[pkgshare/"*.dic"], testpath
     system bin/"mkdssp", "1cbs.cif", "test.dssp"
     assert_match "CELLULAR RETINOIC ACID BINDING PROTEIN TYPE II", (testpath/"test.dssp").read
+
+    # Check if the Python module can be imported
+    system python3, "-c", "import mkdssp"
   end
 end

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -60,8 +60,6 @@ class Dssp < Formula
     end
 
     site_packages_path = Language::Python.site_packages python3
-    mkdir_p site_packages_path
-    chmod 0755, site_packages_path
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",
@@ -70,6 +68,7 @@ class Dssp < Formula
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
+                    "-DPYTHON_SITE_PACKAGES=#{site_packages_path}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -19,7 +19,9 @@ class Dssp < Formula
   depends_on "cmake" => :build
   depends_on "eigen" => :build
   depends_on "boost"
+  depends_on "boost-python3"
   depends_on "icu4c"
+  depends_on "python@3.13"
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
@@ -59,6 +61,7 @@ class Dssp < Formula
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DINSTALL_LIBRARY=ON",
+                    "-DBUILD_PYTHON_MODULE=ON",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -47,6 +47,10 @@ class Dssp < Formula
   end
 
   def install
+    if OS.mac?
+      ENV.prepend "LDFLAGS", "-undefined dynamic_lookup"
+    end
+
     resource("libcifpp").stage do
       # libcifpp should be installed in 'prefix' directory since the path of dic files are always required.
       system "cmake", "-S", ".", "-B", "build", *std_cmake_args(install_prefix: prefix/"libcifpp")
@@ -66,6 +70,7 @@ class Dssp < Formula
     ENV.prepend_create_path "PYTHONPATH", venv.site_packages
     site_packages_path = Language::Python.site_packages python3
     (prefix/site_packages_path/"homebrew-dssp.pth").write venv.site_packages
+    shared_lib_ext = OS.mac? ? "dylib" : "so"
 
     system "cmake", "-S", ".", "-B", "build",
                     "-Dcifpp_DIR=#{prefix/"libcifpp/lib/cmake/cifpp"}",


### PR DESCRIPTION
This pull request updates the `Formula/dssp.rb` file to enhance Python support by adding dependencies and functionality for Python 3.13, including the ability to build and test a Python module. 

### Python support enhancements:

* Added `boost-python3` and `python@3.13` as dependencies to support Python 3.13 functionality.
* Introduced a `python3` method to specify the Python version (`python3.13`) used in the formula.
* Modified the `install` method to create the Python site-packages directory, enable building the Python module (`-DBUILD_PYTHON_MODULE=ON`), and ensure proper installation paths.
* Added a test to verify that the Python module (`mkdssp`) can be successfully imported.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
