### PR TITLE
libcifpp v8.0.1

### DIFF
--- a/Formula/libcifpp.rb
+++ b/Formula/libcifpp.rb
@@ -1,8 +1,8 @@
 class Libcifpp < Formula
   desc "Library containing code to manipulate mmCIF and PDB files"
   homepage "https://pdb-redo.github.io/libcifpp/"
-  url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v7.0.8.tar.gz"
-  sha256 "2297e6649a4f71caf9da5f1d97f59512e7324bb62083bb5b08eb00c1c0385cb3"
+  url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v8.0.1.tar.gz"
+  sha256 "53f0ff205711428dcabf9451b23804091539303cea9d2f54554199144ca0fc4e"
   license "BSD-2-Clause"
   head "https://github.com/PDB-REDO/libcifpp.git", branch: "trunk"
 
@@ -16,13 +16,17 @@ class Libcifpp < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen" => :build
-  depends_on "boost"
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "boost"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
This pull request updates the `Formula/libcifpp.rb` file to reflect changes in the `libcifpp` library version, dependencies, and build configuration. The most important changes include updating the library to version 8.0.1, modifying dependency requirements, and enabling shared library builds.

### Version update:
* Updated `url` to point to version 8.0.1 of the `libcifpp` library and updated the corresponding `sha256` checksum.

### Dependency adjustments:
* Removed the unconditional dependency on `boost` and added a conditional dependency on `boost` for Linux systems only.

### Build configuration:
* Added the `-DBUILD_SHARED_LIBS=ON` flag to the `cmake` command to enable building shared libraries.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
