### PR TITLE
dssp: Use dynamic linking instead of static linking to libcifpp

### DIFF
--- a/Formula/dssp.rb
+++ b/Formula/dssp.rb
@@ -56,13 +56,14 @@ class Dssp < Formula
       "DESTINATION share/libcifpp",
       "DESTINATION #{pkgshare}"
 
+    inreplace "CMakeLists.txt", "${CIFPP_SHARE_DIR}", pkgshare
+
     system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DCMAKE_CXX_STANDARD=20",
                     "-DCMAKE_CXX_FLAGS=#{ENV.cxxflags}",
                     "-DINSTALL_LIBRARY=ON",
                     "-DBUILD_PYTHON_MODULE=ON",
-                    "-DCIFPP_SHARE_DIR=#{pkgshare}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
This pull request updates the `Formula/dssp.rb` file to simplify dependencies, improve compatibility, and enhance build performance. The changes include replacing specific Python version references with a generic `python3`, removing redundant resources, and switching to the Ninja build system for faster compilation.

### Dependency Updates:
* Replaced `python@3.13` with `python3` for compatibility with any Python 3 version.
* Added `ninja` as a build dependency to enable faster builds.

### Resource Removal:
* Removed `libcifpp` and `libmcfp` resources, simplifying the formula and reducing external dependencies.

### Build Process Enhancements:
* Added `-O3` optimization flag to `CXXFLAGS` for improved performance.
* Switched to Ninja build system by adding `-G Ninja` to the CMake configuration.
* Modified Python module installation paths to dynamically adapt based on the Python version.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
