### PR TITLE
gemmi: Enable python bindings

### DIFF
--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -16,6 +16,7 @@ class Gemmi < Formula
 
   depends_on "cmake" => :build
   depends_on "nanobind" => :build
+  depends_on "ninja" => :build
   depends_on "robin-map" => :build
   depends_on "python3"
   depends_on "zlib-ng" # Faster than zlib
@@ -28,7 +29,7 @@ class Gemmi < Formula
     ENV.append "CPPFLAGS", "-I#{Formula["nanobind"].opt_lib/"python#{py_ver}/site-packages/nanobind/include"}"
     ENV.append "CPPFLAGS", "-I#{Formula["python3"].opt_include}/python#{py_ver}"
 
-    system "cmake", "-S", ".", "-B", "build",
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
       "-DCMAKE_CXX_FLAGS=#{ENV["CXXFLAGS"]} #{ENV["CPPFLAGS"]}",
       "-DUSE_PYTHON=ON",
       "-DPYTHON_INSTALL_DIR=#{site_packages}",

--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -18,7 +18,7 @@ class Gemmi < Formula
   depends_on "nanobind" => :build
   depends_on "ninja" => :build
   depends_on "robin-map" => :build
-  depends_on "python3"
+  depends_on "python@3.13"
   depends_on "zlib-ng" # Faster than zlib
 
   def install
@@ -27,7 +27,7 @@ class Gemmi < Formula
     mkdir_p site_packages
 
     ENV.append "CPPFLAGS", "-I#{Formula["nanobind"].opt_lib/"python#{py_ver}/site-packages/nanobind/include"}"
-    ENV.append "CPPFLAGS", "-I#{Formula["python3"].opt_include}/python#{py_ver}"
+    ENV.append "CPPFLAGS", "-I#{Formula["python@3.13"].opt_include}/python#{py_ver}"
 
     system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
       "-DCMAKE_CXX_FLAGS=#{ENV["CXXFLAGS"]} #{ENV["CPPFLAGS"]}",

--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -18,8 +18,7 @@ class Gemmi < Formula
   depends_on "nanobind" => :build
   depends_on "robin-map" => :build
   depends_on "python3"
-
-  uses_from_macos "zlib"
+  depends_on "zlib-ng" # Faster than zlib
 
   def install
     py_ver = Language::Python.major_minor_version "python3"
@@ -33,6 +32,7 @@ class Gemmi < Formula
       "-DCMAKE_CXX_FLAGS=#{ENV["CXXFLAGS"]} #{ENV["CPPFLAGS"]}",
       "-DUSE_PYTHON=ON",
       "-DPYTHON_INSTALL_DIR=#{site_packages}",
+      "-DUSE_ZLIB_NG=ON",
       *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -17,6 +17,7 @@ class Gemmi < Formula
   depends_on "cmake" => :build
   depends_on "nanobind" => :build
   depends_on "python3"
+  depends_on "robin-map"
 
   uses_from_macos "zlib"
 
@@ -25,7 +26,11 @@ class Gemmi < Formula
     site_packages = lib/"python#{py_ver}/site-packages"
     mkdir_p site_packages
 
+    ENV.append "CPPFLAGS", "-I#{Formula["nanobind"].opt_lib/"python#{py_ver}/site-packages/nanobind/include"}"
+    ENV.append "CPPFLAGS", "-I#{Formula["python3"].opt_include}/python#{py_ver}"
+
     system "cmake", "-S", ".", "-B", "build",
+      "-DCMAKE_CXX_FLAGS=#{ENV["CXXFLAGS"]} #{ENV["CPPFLAGS"]}",
       "-DUSE_PYTHON=ON",
       "-DPYTHON_INSTALL_DIR=#{site_packages}",
       *std_cmake_args

--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -1,4 +1,5 @@
 class Gemmi < Formula
+  # cite Wojdyr_2022: "https://doi.org/10.21105/joss.04200"
   desc "Macromolecular crystallography library and utilities"
   homepage "https://project-gemmi.github.io/"
   url "https://github.com/project-gemmi/gemmi/archive/refs/tags/v0.7.3.tar.gz"
@@ -14,11 +15,20 @@ class Gemmi < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "nanobind" => :build
+  depends_on "python3"
 
   uses_from_macos "zlib"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    py_ver = Language::Python.major_minor_version "python3"
+    site_packages = lib/"python#{py_ver}/site-packages"
+    mkdir_p site_packages
+
+    system "cmake", "-S", ".", "-B", "build",
+      "-DUSE_PYTHON=ON",
+      "-DPYTHON_INSTALL_DIR=#{site_packages}",
+      *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
@@ -30,5 +40,8 @@ class Gemmi < Formula
     end
     resource("homebrew-testdata").stage testpath/"example"
     assert_match "_atom_site.B_iso_or_equiv\t1\t218", shell_output("#{bin}/gemmi tags example/5i55.cif")
+
+    # Check if the Python module can be imported
+    system "python3", "-c", "import gemmi"
   end
 end

--- a/Formula/gemmi.rb
+++ b/Formula/gemmi.rb
@@ -16,8 +16,8 @@ class Gemmi < Formula
 
   depends_on "cmake" => :build
   depends_on "nanobind" => :build
+  depends_on "robin-map" => :build
   depends_on "python3"
-  depends_on "robin-map"
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
This pull request updates the `Formula/gemmi.rb` file to enhance the build process and dependencies for the Gemmi formula. Key changes include adding new dependencies, switching to faster libraries, enabling Python module support, and improving installation and testing steps.

### Dependency updates:

- Added new build dependencies: `nanobind`, `ninja`, and `robin-map`. Also added runtime dependencies: `python3` and `zlib-ng` (replacing `zlib` for better performance).

### Build process improvements:

- Updated the `install` method to enable Python module support (`USE_PYTHON=ON`) and set the Python installation directory dynamically based on the Python version. Switched the build system to use Ninja for faster builds. [[1]](diffhunk://#diff-8b615d05c2a2e9926ac7b94fd38dcf985842078b7ff6b6e595162e25d974e1f4L17-R37) [[2]](diffhunk://#diff-8b615d05c2a2e9926ac7b94fd38dcf985842078b7ff6b6e595162e25d974e1f4R49-R51)

### Testing enhancements:

- Added a test to verify that the Python module for Gemmi can be successfully imported.

### Documentation:

- Included a citation for Gemmi in the formula header, referencing the relevant publication.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
