### PR TITLE
Update pull request template for formula submission

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 - [ ] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
 - [ ] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
-- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
+- [ ] Have you built your formula locally with `HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
 - [ ] Does your formula have no offenses with `brew style /path/to/formula.rb`?
 - [ ] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
 - [ ] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?


### PR DESCRIPTION
In recent versions, Homebrew has changed to reject formula installations from local paths by default. 

Added the environment variable `HOMEBREW_DEVELOPER=1` to enable developer mode and allow local installations.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [ ] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [ ] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [ ] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
