### PR TITLE
coot: enable sound support

### DIFF
--- a/Formula/coot.rb
+++ b/Formula/coot.rb
@@ -75,6 +75,8 @@ class Coot < Formula
     sha256 "44db38506f0f90c097d4855ad81a82a36b49cd1e3ffe7d6ee4728b15109e281a"
   end
 
+  patch :DATA
+
   def python3
     "python3.14"
   end
@@ -140,3 +142,15 @@ class Coot < Formula
     assert_match "Usage: coot", shell_output("#{bin}/coot --help 2>&1")
   end
 end
+__END__
+diff --git a/src/molecule-class-info.h b/src/molecule-class-info.h
+index 4a9fb8d0bd..3c634e0fee 100644
+--- a/src/molecule-class-info.h
++++ b/src/molecule-class-info.h
+@@ -34,6 +34,7 @@
+ #endif // HAVE_STRING
+
+ #include <deque>
++#include <iomanip>
+
+ #include "compat/coot-sysdep.h"


### PR DESCRIPTION
This pull request updates the `coot` formula to add support for sound features (introduced in v1.1.20) by adding new dependencies and enabling sound in the build configuration. The main changes are grouped below:

**Dependency additions:**

* Added new dependencies: `libogg`, `libvorbis`, and `openal-soft` to support sound functionality.

**Build configuration improvements:**

* Enabled sound support in the build by adding the `--with-sound` flag to the `configure_args`.

**Source compatibility:**

* Applied an inline patch to include `<iomanip>` in `molecule-class-info.h`, addressing a likely build or compatibility issue.
* Added `patch :DATA` to apply the above patch during the build process.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
