### PR TITLE
coot: Add `--with-coordgen` option to build args

### DIFF
--- a/Formula/coot.rb
+++ b/Formula/coot.rb
@@ -74,8 +74,6 @@ class Coot < Formula
     sha256 "44db38506f0f90c097d4855ad81a82a36b49cd1e3ffe7d6ee4728b15109e281a"
   end
 
-  patch :DATA
-
   def python3
     "python3.14"
   end
@@ -155,15 +153,3 @@ class Coot < Formula
     assert_match "Usage: coot", shell_output("#{bin}/coot --help 2>&1")
   end
 end
-__END__
-diff --git a/src/molecule-class-info.h b/src/molecule-class-info.h
-index 4a9fb8d0bd..3c634e0fee 100644
---- a/src/molecule-class-info.h
-+++ b/src/molecule-class-info.h
-@@ -34,6 +34,7 @@
- #endif // HAVE_STRING
-
- #include <deque>
-+#include <iomanip>
-
- #include "compat/coot-sysdep.h"


### PR DESCRIPTION
See https://github.com/pemsley/coot/issues/161#issuecomment-3703658358.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
