### PR TITLE
coot: add netcdf dep

### DIFF
--- a/Formula/coot.rb
+++ b/Formula/coot.rb
@@ -44,6 +44,7 @@ class Coot < Formula
   depends_on "libpng"
   depends_on "librsvg"
   depends_on "libvorbis"
+  depends_on "netcdf"
   depends_on "numpy"
   depends_on "openal-soft"
   depends_on "openblas"
@@ -138,6 +139,7 @@ class Coot < Formula
       --with-fftw-prefix=#{fftw2_prefix}
       --with-backward
       --with-libdw
+      --with-netcdf
       --with-sound
       BOOST_PYTHON_LIB=#{boost_python_lib}
       PYTHON=#{python3}


### PR DESCRIPTION
Add NetCDF support for reading AMBER trajectories for a v1.2 new feature.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/brewsci/homebrew-bio/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/brewsci/homebrew-bio/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_DEVELOPER=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --keep-tmp ./Formula/<FORMULA>.rb`, where `FORMULA` is the name of the formula you're submitting?
- [x] Does your formula have no offenses with `brew style /path/to/formula.rb`?
- [x] Does your formula pass `brew audit --formula brewsci/bio/<FORMULA> --online --git --skip-style`?
- [x] Does your formula pass `brew linkage --cached --test --strict brewsci/bio/<FORMULA>` after manual installation?

-----
