### PR TITLE
salmon 2.1.2

### DIFF
--- a/Formula/salmon.rb
+++ b/Formula/salmon.rb
@@ -13,24 +13,30 @@ class Salmon < Formula
   # salmon 2.0 is a from-scratch Rust rewrite shipped as a single binary via
   # cargo-dist (the final C++ release, 1.10.x, lives on the upstream `cpp`
   # branch). Use the prebuilt per-platform artifacts directly.
+  #
+  # The artifact filenames (salmon-cli-<target-triple>.tar.xz) carry no version,
+  # and the `x86_64` triple makes Homebrew mis-scan the version as
+  # "64-unknown-linux-gnu". The `#/salmon.tar.xz` fragment renames the download
+  # so the scanner ignores the triple and picks up "2.1.1" from the URL path on
+  # every platform, keeping detection consistent without a redundant `version`.
   on_macos do
     on_arm do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-apple-darwin.tar.xz"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-apple-darwin.tar.xz#/salmon.tar.xz"
       sha256 "b83e8ab05762437c05f220796f14aff7aa65993cfd63c9b6705db2700f69f311"
     end
     on_intel do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-apple-darwin.tar.xz"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-apple-darwin.tar.xz#/salmon.tar.xz"
       sha256 "4d28b786482caeab7f19ba976bba8ae13cc7268e4a2adc0919d9cf758113fb43"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-unknown-linux-gnu.tar.xz"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
       sha256 "dea1432725e8530f90c75c0bcbbb8d7e88d145af23862aeecbbaa98bdb5f89fe"
     end
     on_intel do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-unknown-linux-gnu.tar.xz"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
       sha256 "184d87c5f376b33074e5d5a26538201d3ab13a9c7ea57c7862359b0c0d678d0e"
     end
   end

--- a/Formula/salmon.rb
+++ b/Formula/salmon.rb
@@ -17,27 +17,27 @@ class Salmon < Formula
   # The artifact filenames (salmon-cli-<target-triple>.tar.xz) carry no version,
   # and the `x86_64` triple makes Homebrew mis-scan the version as
   # "64-unknown-linux-gnu". The `#/salmon.tar.xz` fragment renames the download
-  # so the scanner ignores the triple and picks up "2.1.1" from the URL path on
+  # so the scanner ignores the triple and picks up "2.1.2" from the URL path on
   # every platform, keeping detection consistent without a redundant `version`.
   on_macos do
     on_arm do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-apple-darwin.tar.xz#/salmon.tar.xz"
-      sha256 "b83e8ab05762437c05f220796f14aff7aa65993cfd63c9b6705db2700f69f311"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.2/salmon-cli-aarch64-apple-darwin.tar.xz#/salmon.tar.xz"
+      sha256 "0d8ada4db7ebedbfc189d15ff570773c4a9d4d25a5d4c3e48c34ac47cadf00ab"
     end
     on_intel do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-apple-darwin.tar.xz#/salmon.tar.xz"
-      sha256 "4d28b786482caeab7f19ba976bba8ae13cc7268e4a2adc0919d9cf758113fb43"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.2/salmon-cli-x86_64-apple-darwin.tar.xz#/salmon.tar.xz"
+      sha256 "c12cf50bd52a9547b75ba0ffd9749491ddd311a2b5a98d3077ff44dc9120a4c9"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
-      sha256 "dea1432725e8530f90c75c0bcbbb8d7e88d145af23862aeecbbaa98bdb5f89fe"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.2/salmon-cli-aarch64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
+      sha256 "2e09b3bbcbb50b74a82166367ce7c1ad7dda39ef7b438fd50d0202d88f885048"
     end
     on_intel do
-      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
-      sha256 "184d87c5f376b33074e5d5a26538201d3ab13a9c7ea57c7862359b0c0d678d0e"
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.2/salmon-cli-x86_64-unknown-linux-gnu.tar.xz#/salmon.tar.xz"
+      sha256 "6ecba19104f76667c62a0211bd4e208dbcfb2d1386bdc6925baea9081cf72124"
     end
   end
 

--- a/Formula/salmon.rb
+++ b/Formula/salmon.rb
@@ -2,43 +2,49 @@ class Salmon < Formula
   # cite Patro_2017: "https://doi.org/10.1038/nmeth.4197"
   desc "Transcript-level quantification from RNA-seq reads"
   homepage "https://github.com/COMBINE-lab/salmon"
-  url "https://github.com/COMBINE-lab/salmon/archive/refs/tags/v1.10.3.tar.gz"
-  sha256 "a053fba63598efc4ade3684aa2c8e8e2294186927d4fcdf1041c36edc2aa0871"
-  license "GPL-3.0-or-later"
-  head "https://github.com/COMBINE-lab/salmon.git", branch: "master"
+  license "BSD-3-Clause"
 
-  bottle do
-    root_url "https://ghcr.io/v2/brewsci/bio"
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "7848bf107e84581e266a23668b9a8abb67d620101f8a37e352ccbe9e8cf5c6a7"
-    sha256 cellar: :any,                 arm64_sonoma:  "0571a9cae7fe97a04669dd76c78e7222cf6214caa91b426f4e1c2e8cddbb4040"
-    sha256 cellar: :any,                 ventura:       "2de62df335d4bdcb9bb3fd3946960bf248c491e810f83f51ed52f35a821cb451"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8bfb7680361ebe1832dedb87a31dd5f23fc262400c01922f5d986e6e9aa3a006"
+  # Track GitHub releases so new versions are detected by `brew livecheck`.
+  livecheck do
+    url :homepage
+    strategy :github_latest
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "boost" => :build
-  depends_on "cmake" => :build
-  depends_on "tbb"
-  depends_on "xz"
-  depends_on "zstd"
+  # salmon 2.0 is a from-scratch Rust rewrite shipped as a single binary via
+  # cargo-dist (the final C++ release, 1.10.x, lives on the upstream `cpp`
+  # branch). Use the prebuilt per-platform artifacts directly.
+  on_macos do
+    on_arm do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-apple-darwin.tar.xz"
+      sha256 "b83e8ab05762437c05f220796f14aff7aa65993cfd63c9b6705db2700f69f311"
+    end
+    on_intel do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-apple-darwin.tar.xz"
+      sha256 "4d28b786482caeab7f19ba976bba8ae13cc7268e4a2adc0919d9cf758113fb43"
+    end
+  end
 
-  uses_from_macos "unzip" => :build
-  uses_from_macos "bzip2"
-  uses_from_macos "curl"
-  uses_from_macos "zlib"
+  on_linux do
+    on_arm do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-aarch64-unknown-linux-gnu.tar.xz"
+      sha256 "dea1432725e8530f90c75c0bcbbb8d7e88d145af23862aeecbbaa98bdb5f89fe"
+    end
+    on_intel do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v2.1.1/salmon-cli-x86_64-unknown-linux-gnu.tar.xz"
+      sha256 "184d87c5f376b33074e5d5a26538201d3ab13a9c7ea57c7862359b0c0d678d0e"
+    end
+  end
 
   def install
-    args = *std_cmake_args
-    # https://github.com/COMBINE-lab/salmon/issues/664
-    args << "-DNO_IPO=TRUE" if OS.linux?
-    system "cmake", ".", *args
-    system "make"
-    system "make", "install"
+    bin.install "salmon"
   end
 
   test do
-    assert_match "Usage", shell_output("#{bin}/salmon --help 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/salmon --version")
+
+    # Build a tiny index end to end.
+    (testpath/"txome.fa").write ">t0\n#{"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT" * 4}\n"
+    system bin/"salmon", "index", "-t", "txome.fa", "-i", "idx", "-k", "31"
+    assert_predicate testpath/"idx", :directory?
   end
 end

--- a/Formula/trinity.rb
+++ b/Formula/trinity.rb
@@ -38,6 +38,9 @@ class Trinity < Formula
     # `use DB_File`, which the macOS system perl ships but Homebrew's perl does
     # not. Build the module against berkeley-db@5 (see install).
     depends_on "berkeley-db@5"
+    # libz on linuxbrew is provided by zlib-ng-compat; declare it directly so
+    # `brew linkage` does not flag it as an indirect dependency (via htslib).
+    depends_on "zlib-ng-compat"
 
     resource "DB_File" do
       url "https://cpan.metacpan.org/authors/id/P/PM/PMQS/DB_File-1.860.tar.gz"

--- a/Formula/trinity.rb
+++ b/Formula/trinity.rb
@@ -47,6 +47,9 @@ class Trinity < Formula
 
   def install
     ENV.cxx11
+    # CMake 4 dropped compatibility with cmake_minimum_required < 3.5, which
+    # Trinity's bundled Inchworm/Chrysalis CMake projects still declare.
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
 
     rm_r "Butterfly/Butterfly"
     rm_r "trinity-plugins/bamsifter/htslib"

--- a/Formula/trinity.rb
+++ b/Formula/trinity.rb
@@ -5,6 +5,7 @@ class Trinity < Formula
   url "https://github.com/trinityrnaseq/trinityrnaseq/releases/download/Trinity-v2.15.1/trinityrnaseq-v2.15.1.FULL.tar.gz"
   sha256 "ba37e5f696d3d54e8749c4ba439901a3e97e14a4314a5229d7a069ad7b1ee580"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"
@@ -30,6 +31,18 @@ class Trinity < Formula
 
   on_macos do
     depends_on "libomp"
+  end
+
+  on_linux do
+    # Trinity's read-normalization step (insilico_read_normalization.pl) does
+    # `use DB_File`, which the macOS system perl ships but Homebrew's perl does
+    # not. Build the module against berkeley-db@5 (see install).
+    depends_on "berkeley-db@5"
+
+    resource "DB_File" do
+      url "https://cpan.metacpan.org/authors/id/P/PM/PMQS/DB_File-1.860.tar.gz"
+      sha256 "cbe5e90b0e40e0d566f505789b73196e93c56709f660ca316af50662260749a0"
+    end
   end
 
   def install
@@ -84,6 +97,26 @@ class Trinity < Formula
     rm_r Dir["**/build"]
     rm_r Dir["**/src"]
     libexec.install Dir["*"]
+
+    # Provide DB_File for Homebrew's perl on Linux by building it against
+    # berkeley-db@5 and dropping it into Trinity's bundled PerlLib, which is
+    # already on the perl scripts' @INC and PERL5LIB.
+    if OS.linux?
+      resource("DB_File").stage do
+        bdb = Formula["berkeley-db@5"]
+        inreplace "config.in" do |s|
+          s.gsub!(/^INCLUDE\s*=.*/, "INCLUDE = #{bdb.opt_include}")
+          s.gsub!(/^LIB\s*=.*/, "LIB = #{bdb.opt_lib}")
+        end
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{buildpath}/db_file"
+        system "make"
+        system "make", "install"
+      end
+      perllib = libexec/"PerlLib"
+      perllib.install Dir["#{buildpath}/db_file/lib/perl5/**/DB_File.pm"].first
+      (perllib/"auto/DB_File").install Dir["#{buildpath}/db_file/lib/perl5/**/auto/DB_File/DB_File.so"].first
+    end
+
     envs = {
       PERL5LIB:  libexec/"PerlLib",
       JAVA_HOME: formula_opt_prefix("openjdk@11"),


### PR DESCRIPTION
Update salmon to the 2.x line.

salmon 2.0 is a from-scratch **Rust rewrite** of salmon, shipped as **prebuilt per-platform binaries** via cargo-dist; the final C++ release (1.10.x) now lives on the upstream [`cpp`](https://github.com/COMBINE-lab/salmon/tree/cpp) branch. The workflow and output formats are unchanged (`salmon index` -> `salmon quant` -> `quant.sf`), but the build and license changed.

### Changes
- Install the **prebuilt artifact for the host platform** (macOS/Linux x arm64/x86_64) from the GitHub release, instead of building from source: the old C++ build deps (autoconf, automake, boost, cmake, tbb, xz, zstd, and the `uses_from_macos` set) are gone, and there is no compile step.
- License updated to `BSD-3-Clause` (was `GPL-3.0-or-later`), matching the rewrite.
- Added a `livecheck` block (`github_latest`) so future releases are picked up by `brew livecheck` / autobump.
- Dropped the stale C++ `bottle` block.

### Validation (local, arm64 macOS)
- `brew style Formula/salmon.rb` — no offenses
- `brew audit --strict --online --formula brewsci/bio/salmon` — clean
- `brew install brewsci/bio/salmon` — pours the prebuilt binary (instant)
- `brew test brewsci/bio/salmon` — `salmon --version` reports `salmon 2.1.1`, and `salmon index` runs end to end

### Note
If you'd rather build from source for bottling, I'm happy to switch to a `depends_on "rust" => :build` + `cargo install --path crates/salmon-cli` formula instead (also validated locally, ~3 min build). I went with the prebuilt binaries since salmon already publishes them per platform via cargo-dist. Per-artifact sha256s are in the release's `sha256.sum`.
