### PR TITLE
salmon@1 1.12.1 (new formula)

### DIFF
--- a/Formula/salmon@1.rb
+++ b/Formula/salmon@1.rb
@@ -4,6 +4,13 @@ class SalmonAT1 < Formula
   homepage "https://github.com/COMBINE-lab/salmon"
   license "GPL-3.0-or-later"
 
+  # Track only the legacy C++ 1.x line; never follow the 2.x Rust releases.
+  livecheck do
+    url :homepage
+    regex(/^v?(1(?:\.\d+)+)$/i)
+    strategy :github_releases
+  end
+
   # salmon 2.0 is a Rust rewrite shipped as the unversioned `salmon` formula.
   # This keeps the final C++ release (1.x line) available alongside it via the
   # upstream prebuilt binaries. Both provide a `salmon` binary, so stay

--- a/Formula/salmon@1.rb
+++ b/Formula/salmon@1.rb
@@ -1,0 +1,46 @@
+class SalmonAT1 < Formula
+  # cite Patro_2017: "https://doi.org/10.1038/nmeth.4197"
+  desc "Transcript-level quantification from RNA-seq reads (C++ 1.x line)"
+  homepage "https://github.com/COMBINE-lab/salmon"
+  license "GPL-3.0-or-later"
+
+  # salmon 2.0 is a Rust rewrite shipped as the unversioned `salmon` formula.
+  # This keeps the final C++ release (1.x line) available alongside it via the
+  # upstream prebuilt binaries. Both provide a `salmon` binary, so stay
+  # keg-only to avoid a link conflict.
+  #
+  # The release filenames (salmon-<os>-<arch>.tar.gz) carry no version, so the
+  # `#/salmon.tar.gz` fragment renames the download and lets Homebrew read
+  # "1.12.1" from the URL path consistently on every platform.
+  keg_only :versioned_formula
+
+  on_macos do
+    on_arm do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v1.12.1/salmon-macos-arm64.tar.gz#/salmon.tar.gz"
+      sha256 "66a711fc594f0cfe3310885b7c3b94820b51ecef8fbfbf3598fad38f5be51831"
+    end
+    on_intel do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v1.12.1/salmon-macos-x86_64.tar.gz#/salmon.tar.gz"
+      sha256 "b40dcd0686ffe9f93cbf2105dcfbe4a4db6819971b420d257ea47f25be9a26e4"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v1.12.1/salmon-linux-aarch64.tar.gz#/salmon.tar.gz"
+      sha256 "fccee6d68d72ad3f5afdc2d9c54b84c5b66b175005e9a97763d75d25722a3017"
+    end
+    on_intel do
+      url "https://github.com/COMBINE-lab/salmon/releases/download/v1.12.1/salmon-linux-x86_64.tar.gz#/salmon.tar.gz"
+      sha256 "00900135ecca10b45e3d78a6ab64463f957d0b2b0069eaa078c10784f1e2f8d6"
+    end
+  end
+
+  def install
+    bin.install "bin/salmon"
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/salmon --help 2>&1")
+  end
+end


### PR DESCRIPTION
## salmon@1 1.12.1 (new formula)

salmon 2.0 is a from-scratch Rust rewrite, now shipped as the unversioned `salmon` formula (see #2190). This adds `salmon@1` to preserve the **final C++ release** (the 1.x legacy line, the way bioconda keeps it available) for users who still depend on it.

### Approach
- Uses the upstream **prebuilt per-platform binaries** from the `v1.12.1` release (macOS arm64/x86_64, Linux aarch64/x86_64), mirroring how `salmon` 2.x is packaged.
- `keg_only :versioned_formula` — both formulae provide a `salmon` binary, so this stays unlinked to avoid a conflict.
- `#/salmon.tar.gz` download-rename fragment so Homebrew reads `1.12.1` from the URL path consistently (the release filenames carry no version).

### Validation (local, arm64)
- `brew style` + `brew audit --new`: clean.
- `brew install` + `brew test`: pass; binary reports `salmon 1.12.1`.
- Confirmed keg-only coexistence with `salmon` 2.x (no link conflict).
- macOS binary links only system libraries (`/usr/lib/*`), so linkage is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
