### PR TITLE
ci: only build bottles when formulae change

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -1,6 +1,11 @@
 name: Build bottles
 
-on: pull_request
+# Only build bottles when a formula actually changes; this avoids the `merge`
+# job failing on PRs that touch no formulae (no bottles -> no artifacts).
+on:
+  pull_request:
+    paths:
+      - Formula/**
 
 env:
   HOMEBREW_NO_ANALYTICS: 1


### PR DESCRIPTION
Restricts the `Build bottles` workflow to PRs that actually change a formula.

### Why
The `merge` job (`actions/upload-artifact/merge`) aggregates the `bottles-*` artifacts produced by the build jobs. On a PR that touches no formula (e.g. a workflow or docs change), the build jobs produce no bottle artifacts, so `merge` fails with `No artifacts found matching pattern 'bottles-*'`. That is a spurious red check on otherwise valid PRs.

### Change
Adds a `paths: Formula/**` filter to the `pull_request` trigger, so the bottle pipeline only runs when a formula changes. Formula PRs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
