### PR TITLE
gmap-gsnap 2025-07-31

### DIFF
--- a/Formula/gmap-gsnap.rb
+++ b/Formula/gmap-gsnap.rb
@@ -2,8 +2,14 @@ class GmapGsnap < Formula
   # cite Wu_2010: "https://doi.org/10.1093/bioinformatics/btq057"
   desc "Genomic Mapping & Alignment Program for RNA/EST/Short-read sequences"
   homepage "http://research-pub.gene.com/gmap/"
-  url "http://research-pub.gene.com/gmap/src/gmap-gsnap-2019-09-12.tar.gz"
-  sha256 "1bf242eef2ad0ab0280c41fc28b44a5107e90bcba64b37cf1579e1793e892505"
+  url "http://research-pub.gene.com/gmap/src/gmap-gsnap-2025-07-31.v2.tar.gz"
+  sha256 "c4a0121d84edb7c887ea6a6c1dfc6b2f21aaaa7e663a72b8962a07e8ea125b56"
+
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(/href=.*?gmap-gsnap-(\d\d\d\d-\d\d-\d\d)(\.v\d+)?\.t/i)
+  end
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"
@@ -17,9 +23,13 @@ class GmapGsnap < Formula
   uses_from_macos "zlib"
 
   def install
-    # homebrew currently supports SSE4.2 and don't want to force AVX-512
-    system "./configure", "--prefix=#{prefix}", "--with-simd-level=sse42"
+    # gmap 2025 builds several SIMD-level binaries (sse42, avx2, nosimd, ...)
+    # and dispatches at runtime, so the bottle stays portable without pinning
+    # a level (and --with-simd-level=sse42 no longer builds in this release).
+    system "./configure", "--prefix=#{prefix}"
     system "make"
+    # The test suite shares output files between cases and races under a
+    # parallel make, so run it serially.
     ENV.deparallelize
     system "make", "check"
     system "make", "install"
@@ -37,6 +47,7 @@ class GmapGsnap < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/gmap --version 2>&1")
     assert_match version.to_s, shell_output("#{bin}/gsnap --version 2>&1")
   end
 end

--- a/Formula/gmap-gsnap.rb
+++ b/Formula/gmap-gsnap.rb
@@ -22,6 +22,12 @@ class GmapGsnap < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  # The binary links libz, provided by zlib-ng-compat on Linux; declare it
+  # directly so it is not flagged as an indirect-dependency linkage.
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
   def install
     # gmap 2025 builds several SIMD-level binaries (sse42, avx2, nosimd, ...)
     # and dispatches at runtime, so the bottle stays portable without pinning


### PR DESCRIPTION
Bumps `gmap-gsnap` 2019-09-12 → 2025-07-31 (latest upstream).

Supersedes #2169, whose CI failed on `make check` (3 of 4 tests). Root-caused and fixed locally:

- **Test race:** the upstream test suite shares output files between cases and fails under a parallel `make check`. Running it serially (`ENV.deparallelize`, as the pre-2169 formula did) makes all tests pass. This was the actual CI failure.
- **SIMD:** the 2025 release builds multiple SIMD-level binaries (`gmap_sse42`, `gsnapl_avx2`, `gsnapl_nosimd`, ...) and dispatches at runtime, so `--with-simd-level=sse42` is dropped (it no longer builds in this release) while bottles remain portable across CPUs.
- Adds a `livecheck` block (kept from #2169).

Verified locally on arm64 macOS: builds in ~72s, `make check` passes, `gmap`/`gsnap --version` report `2025-07-31`, and `brew test`/`brew style` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)