### PR TITLE
bismark: note that v2 (Rust rewrite) needs a manual rewrite

### DIFF
--- a/Formula/bismark.rb
+++ b/Formula/bismark.rb
@@ -6,6 +6,10 @@ class Bismark < Formula
   sha256 "b7e69f8e4893059f73863a8d2835245e70132715fdf49163b453bb7c0a8de61d"
   license "GPL-3.0-or-later"
 
+  # NOTE: Bismark v2 is a Rust rewrite. When livecheck/autobump detects it, the
+  # version-bump PR will only change url/sha256 and WILL fail: the v2 tarball
+  # has no Perl scripts. It needs a full formula rewrite (depends_on "rust" =>
+  # :build, a cargo build, and revised runtime deps) rather than an auto-bump.
   livecheck do
     url :stable
     strategy :github_latest


### PR DESCRIPTION
Adds a comment next to bismark's `livecheck` block warning that the eventual Bismark v2 (a Rust rewrite) cannot be handled by an automatic version bump.

When livecheck/autobump detects v2, the auto-generated PR will only change `url`/`sha256`/`version` — but the v2 tarball ships no Perl scripts, so `libexec.install scripts` would fail. v2 will need a full formula rewrite (`depends_on "rust" => :build`, a `cargo` build, and revised runtime deps). The note flags this for whoever handles that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)