### PR TITLE
mosdepth 0.3.14

### DIFF
--- a/Formula/mosdepth.rb
+++ b/Formula/mosdepth.rb
@@ -7,14 +7,6 @@ class Mosdepth < Formula
   license "MIT"
   head "https://github.com/brentp/mosdepth.git", branch: "master"
 
-  bottle do
-    root_url "https://ghcr.io/v2/brewsci/bio"
-    sha256 cellar: :any,                 arm64_sequoia: "f6b9c535f17ba87c89c374a2cd8b3dc0074a5be8fae367b3dfcece578f6db334"
-    sha256 cellar: :any,                 arm64_sonoma:  "6b3d07a358bda492f13e81c2caddc632d13ed16ff92eec02643af16e28e90667"
-    sha256 cellar: :any,                 ventura:       "053e7e2bc5c911d75fc2d6139d22bd01965f8a05ed56609ce9eacaa65601aab6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1f6301e7f4c83badb6393379bdc861b7e9b5f412ba2af625b06e026c631ee3f9"
-  end
-
   depends_on "nim" => :build
   depends_on "brewsci/bio/d4tools"
   depends_on "bwa"

--- a/Formula/mosdepth.rb
+++ b/Formula/mosdepth.rb
@@ -2,8 +2,8 @@ class Mosdepth < Formula
   # cite Pederson_2017: "https://doi.org/10.1093/bioinformatics/btx699"
   desc "Fast BAM/CRAM depth calculator"
   homepage "https://github.com/brentp/mosdepth"
-  url "https://github.com/brentp/mosdepth/archive/refs/tags/v0.3.11.tar.gz"
-  sha256 "4becd1e74a81ed590588ed2745ef7f1443d0a5aad35f9880a2d452d56a7227ff"
+  url "https://github.com/brentp/mosdepth/archive/refs/tags/v0.3.14.tar.gz"
+  sha256 "abac67de4547dc5642efd46846044d6b3536d2ca3443b4ca172446edf82eeb42"
   license "MIT"
   head "https://github.com/brentp/mosdepth.git", branch: "master"
 


### PR DESCRIPTION
Bumps mosdepth to [0.3.14](https://github.com/brentp/mosdepth/releases/tag/v0.3.14) (upstream fix for a requested region starting past the end of a chromosome).

Rebuilding across the current macOS lineup also produces the missing `arm64_tahoe` (macOS 26) bottle. mosdepth currently ships only `arm64_sequoia`/`arm64_sonoma`, which is why #2205 (smoove) is skipped on macos-26 with `smoove has unbottled dependencies`. This PR unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)