### PR TITLE
ci: untap external taps instead of trusting them (fixes ubuntu-latest)

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -31,12 +31,13 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
 
-      - name: Trust external taps
-        run: |
-          brew tap aws/tap
-          brew tap azure/bicep
-          brew trust aws/tap
-          brew trust azure/bicep
+      - name: Remove pre-installed external taps
+        # The GitHub runner images ship the aws/tap and azure/bicep taps, which
+        # are irrelevant to this tap. They were previously trusted to satisfy
+        # brew's tap-trust requirement, but `brew trust` now fails on Linux with
+        # "Unexpected platform!", breaking every PR's ubuntu-latest job. Untap
+        # them instead so the trust check has nothing to flag.
+        run: brew untap --force aws/tap azure/bicep 2>/dev/null || true
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
## Problem

Every PR's `build-bottles (ubuntu-latest)` job currently fails after ~1 minute, during CI setup and before any formula is built:

```
==> Trust external taps
brew tap aws/tap
brew tap azure/bicep
brew trust aws/tap
brew trust azure/bicep
...
##[error]Unexpected platform!
##[error]Process completed with exit code 1.
```

The "Trust external taps" step (added in c70fbefb) trusts the `aws/tap` and `azure/bicep` taps that ship pre-installed on the GitHub runner images, to satisfy brew's tap-trust requirement. Since a recent `brew` change, **`brew trust` fails on Linux** with `Unexpected platform!` (raised from `Library/Homebrew/github_runner_matrix.rb`), so the step errors out and the whole ubuntu-latest job dies.

This is tap-wide: it broke for every branch at roughly the same time today (e.g. mosdepth's ubuntu job passed at 16:16, smoove's identical setup failed at 17:22). The macOS jobs are unaffected.

## Fix

These taps are irrelevant to brewsci/bio, so **untap** them instead of trusting them. The tap-trust check then has nothing to flag, and the broken `brew trust` call is avoided entirely. `--force` and `|| true` keep the step robust if a runner image stops shipping them.

```yaml
- name: Remove pre-installed external taps
  run: brew untap --force aws/tap azure/bicep 2>/dev/null || true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)