### PR TITLE
Autobump: run hourly, tolerate per-formula failures, add direct GitHub-tag fallback

### DIFF
--- a/.github/scripts/autobump-git-direct.sh
+++ b/.github/scripts/autobump-git-direct.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Fallback autobump for formulae that livecheck cannot resolve.
+#
+# `brew bump` relies on each formula's `livecheck` block. For formulae whose
+# upstream cannot be checked that way (livecheck reports "Unable to get
+# versions"), this script reads the upstream GitHub tags directly and opens a
+# version-bump PR when a newer *stable* tag exists.
+#
+# It is best-effort: every step tolerates failures so one bad formula never
+# aborts the run. Only GitHub-hosted sources can be handled; formulae on lab
+# pages / FTP mirrors are skipped (no tags to read).
+#
+# Requires: HOMEBREW_GITHUB_API_TOKEN (opens the PRs) and GH_TOKEN (gh api).
+set -uo pipefail
+
+tap="brewsci/bio"
+
+echo "==> Collecting formulae that livecheck cannot resolve"
+mapfile -t blind < <(
+  brew livecheck --tap "$tap" --formulae 2>&1 \
+    | grep -iE 'unable to get versions|no version information' \
+    | grep -oE "$tap/[A-Za-z0-9._@+-]+" \
+    | sed "s#$tap/##" \
+    | sort -u
+)
+echo "    ${#blind[@]} livecheck-blind formulae"
+
+bumped=0
+for f in "${blind[@]}"; do
+  info=$(brew info --json=v2 --formula "$tap/$f" 2>/dev/null) || continue
+
+  cur=$(jq -r '.formulae[0].versions.stable // empty' <<<"$info")
+  [ -z "$cur" ] && continue
+
+  # Canonical GitHub "owner/repo" from the stable URL, head URL, or homepage.
+  repo=$(jq -r '.formulae[0] | (.urls.stable.url // ""), (.urls.head.url // ""), (.homepage // "")' <<<"$info" \
+    | grep -oiE 'github\.com[/:][^/"]+/[^/"[:space:]]+' \
+    | head -1 \
+    | sed -E 's#.*github\.com[/:]##; s#\.git$##')
+  [ -z "$repo" ] && continue
+
+  # Latest stable tag: numeric, no pre-release markers, leading v/V stripped.
+  latest=$(gh api "repos/$repo/tags" --paginate --jq '.[].name' 2>/dev/null \
+    | grep -iE '^v?[0-9]' \
+    | grep -viE 'rc|beta|alpha|-?pre|dev|snapshot|nightly' \
+    | sed -E 's/^[vV]//' \
+    | sort -V \
+    | tail -1)
+  [ -z "$latest" ] && continue
+
+  # Only bump when the newest tag is strictly greater than the current version.
+  newest=$(printf '%s\n%s\n' "$cur" "$latest" | sort -V | tail -1)
+  if [ "$newest" = "$latest" ] && [ "$cur" != "$latest" ]; then
+    echo "==> git-direct bump: $f $cur -> $latest ($repo)"
+    if brew bump-formula-pr --no-audit --no-browse --version="$latest" "$tap/$f"; then
+      bumped=$((bumped + 1))
+    else
+      echo "    bump failed for $f -> $latest (skipped)"
+    fi
+  fi
+done
+
+echo "==> git-direct opened $bumped PR(s)"

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       formulae:
-        description: Space-separated formulae to livecheck and bump (default: all outdated)
+        description: "Space-separated formulae to livecheck and bump (default: all outdated)"
         required: false
   push:
     branches: [develop, master]

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -24,6 +24,15 @@ on:
     # release". `brew bump` de-duplicates, so it never re-opens an existing PR.
     - cron: "0 * * * *"
   workflow_dispatch:
+    inputs:
+      formulae:
+        description: Space-separated formulae to livecheck and bump (default: all outdated)
+        required: false
+  push:
+    branches: [develop, master]
+    paths:
+      - .github/workflows/autobump.yml
+      - .github/scripts/autobump-git-direct.sh
 
 permissions:
   contents: read
@@ -58,9 +67,18 @@ jobs:
         continue-on-error: true
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          # Optional custom list from workflow_dispatch (mirrors homebrew-core's
+          # autobump input). `brew bump --auto` is official-repos-only, so a
+          # third-party tap iterates all its formulae by default instead.
+          FORMULAE: ${{ inputs.formulae }}
         run: |
           set -o pipefail
-          brew bump --tap brewsci/bio --formulae --open-pr 2>&1 | tee bump.log || true
+          BUMP=(brew bump --tap brewsci/bio --formulae --open-pr)
+          if [[ -n "${FORMULAE-}" ]]; then
+            "${BUMP[@]}" ${FORMULAE} 2>&1 | tee bump.log || true
+          else
+            "${BUMP[@]}" 2>&1 | tee bump.log || true
+          fi
           {
             echo "### Autobump (livecheck)"
             grep -iE 'bump|pull request|error|failed|up to date' bump.log | tail -60 || true

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,7 +1,15 @@
 name: Autobump
 
-# Opens version-bump pull requests for outdated formulae, using each formula's
-# `livecheck` block to detect new upstream releases.
+# Opens version-bump pull requests for outdated formulae.
+#
+#   1. Primary: `brew bump --open-pr`, using each formula's `livecheck` block to
+#      detect new upstream releases.
+#   2. Fallback: `.github/scripts/autobump-git-direct.sh` handles formulae whose
+#      livecheck cannot resolve a version by reading upstream GitHub tags directly.
+#
+# Individual formula errors (dead upstreams, bogus livecheck 404s, audit
+# failures) are tolerated via `continue-on-error` so one bad formula never fails
+# the whole scheduled run; a per-step summary records what happened.
 #
 # Requires a repository secret named `HOMEBREW_GITHUB_API_TOKEN`: a Personal
 # Access Token (classic `public_repo`/`repo` scope, or a fine-grained token with
@@ -11,8 +19,10 @@ name: Autobump
 
 on:
   schedule:
-    # Mondays at 05:00 UTC
-    - cron: "0 5 * * 1"
+    # Hourly. GitHub Actions cannot subscribe to external repos' release events,
+    # so this polls as often as is practical to approximate "bump on upstream
+    # release". `brew bump` de-duplicates, so it never re-opens an existing PR.
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -42,7 +52,29 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Open version-bump PRs for outdated formulae
+      - name: Open version-bump PRs (livecheck)
+        # Tolerate per-formula failures: still open every valid PR and keep the
+        # scheduled run green even when some upstreams are dead or misdetected.
+        continue-on-error: true
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-        run: brew bump --tap brewsci/bio --formulae --open-pr
+        run: |
+          set -o pipefail
+          brew bump --tap brewsci/bio --formulae --open-pr 2>&1 | tee bump.log || true
+          {
+            echo "### Autobump (livecheck)"
+            grep -iE 'bump|pull request|error|failed|up to date' bump.log | tail -60 || true
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open version-bump PRs (direct GitHub tags)
+        # Fallback for formulae livecheck cannot resolve. Also best-effort.
+        continue-on-error: true
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        run: |
+          bash .github/scripts/autobump-git-direct.sh 2>&1 | tee git-direct.log || true
+          {
+            echo "### Autobump (direct GitHub tags)"
+            grep -iE 'git-direct|blind' git-direct.log | tail -60 || true
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The weekly Autobump runs have been failing (exit 1) because a single formula's
error aborts the whole job — e.g. `webin-cli` (livecheck reports a bogus `9.0.3`
→ 404) and `voronota` (`brew audit` failure). Valid bump PRs still get opened,
but the run is marked red every week.

This makes the workflow more reactive and resilient:

1. **Hourly schedule.** GitHub Actions cannot subscribe to external upstream
   repos' release events, so the cron is moved from weekly to hourly to
   approximate "bump as soon as a new version is published". `brew bump`
   de-duplicates, so it never re-opens an existing PR.

2. **Tolerate per-formula failures.** The `brew bump --open-pr` step now runs
   with `continue-on-error: true` and writes a step summary. Dead upstreams,
   misdetected versions, or audit failures no longer fail the scheduled run;
   the valid bump PRs are still opened.

3. **Direct GitHub-tag fallback.** A new step
   (`.github/scripts/autobump-git-direct.sh`) handles formulae whose `livecheck`
   returns "Unable to get versions" by reading the upstream GitHub tags directly
   and opening a bump PR when a newer stable tag exists. Non-GitHub sources are
   skipped; `brew bump-formula-pr` validates the tag on download.

The required `HOMEBREW_GITHUB_API_TOKEN` secret is unchanged.