### PR TITLE
clonalframeml 1.20

### DIFF
--- a/Formula/clonalframeml.rb
+++ b/Formula/clonalframeml.rb
@@ -2,8 +2,8 @@ class Clonalframeml < Formula
   # cite Didelot_2015: "https://doi.org/10.1371/journal.pcbi.1004041"
   desc "Efficient Inference of Recombination in Bacterial Genomes"
   homepage "https://github.com/xavierdidelot/ClonalFrameML"
-  url "https://github.com/xavierdidelot/ClonalFrameML/archive/refs/tags/v1.12.tar.gz"
-  sha256 "ef76705c1a0f1343184f956cd0bdc96c2cfdbb998177330b09b6df84c74c2de6"
+  url "https://github.com/xavierdidelot/ClonalFrameML/archive/refs/tags/v1.20.tar.gz"
+  sha256 "ae797b187793599876a325cd5011959c82fc2b0f72b11b973b0cd1a3d47f6fb2"
   license "GPL-3.0"
   head "https://github.com/xavierdidelot/ClonalFrameML.git"
 

--- a/Formula/clonalframeml.rb
+++ b/Formula/clonalframeml.rb
@@ -5,7 +5,7 @@ class Clonalframeml < Formula
   url "https://github.com/xavierdidelot/ClonalFrameML/archive/refs/tags/v1.20.tar.gz"
   sha256 "ae797b187793599876a325cd5011959c82fc2b0f72b11b973b0cd1a3d47f6fb2"
   license "GPL-3.0"
-  head "https://github.com/xavierdidelot/ClonalFrameML.git"
+  head "https://github.com/xavierdidelot/ClonalFrameML.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"


### PR DESCRIPTION
Bump `clonalframeml` to 1.20. Detected via `brew livecheck`.