### PR TITLE
gappa 0.9.0

### DIFF
--- a/Formula/gappa.rb
+++ b/Formula/gappa.rb
@@ -3,8 +3,8 @@ class Gappa < Formula
   # cite Czech_2018: "https://doi.org/10.1101/346353"
   desc "Genesis Applications for Phylogenetic Placement Analysis"
   homepage "https://github.com/lczech/gappa"
-  url "https://github.com/lczech/gappa/archive/refs/tags/v0.6.1.tar.gz"
-  sha256 "38d643706b6179347460fb535dbbb07424f38d52e38d631b293484ee1627ac65"
+  url "https://github.com/lczech/gappa/archive/refs/tags/v0.9.0.tar.gz"
+  sha256 "6c3e64c6621d1a3ae2ab9f7a3af8d6d130f35e3b260ab659ebf6b60e8364d126"
   license "GPL-3.0-or-later"
   head "https://github.com/lczech/gappa.git"
 

--- a/Formula/gappa.rb
+++ b/Formula/gappa.rb
@@ -6,7 +6,7 @@ class Gappa < Formula
   url "https://github.com/lczech/gappa/archive/refs/tags/v0.9.0.tar.gz"
   sha256 "6c3e64c6621d1a3ae2ab9f7a3af8d6d130f35e3b260ab659ebf6b60e8364d126"
   license "GPL-3.0-or-later"
-  head "https://github.com/lczech/gappa.git"
+  head "https://github.com/lczech/gappa.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"
@@ -26,7 +26,7 @@ class Gappa < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5", *std_cmake_args
       system "make"
     end
     bin.install "bin/gappa"

--- a/Formula/gappa.rb
+++ b/Formula/gappa.rb
@@ -25,8 +25,12 @@ class Gappa < Formula
   fails_with :clang # needs openmp
 
   def install
+    # gappa downloads and configures CLI11/genesis/sparsepp in nested cmake
+    # runs that do not inherit the -D flag; the env var propagates to them and
+    # satisfies their removed "CMake < 3.5" compatibility requirement.
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     mkdir "build" do
-      system "cmake", "..", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5", *std_cmake_args
+      system "cmake", "..", *std_cmake_args
       system "make"
     end
     bin.install "bin/gappa"


### PR DESCRIPTION
Bump `gappa` to 0.9.0. Detected via `brew livecheck`.