### PR TITLE
krona 2.8.1

### DIFF
--- a/Formula/krona.rb
+++ b/Formula/krona.rb
@@ -2,8 +2,8 @@ class Krona < Formula
   # cite Ondov_2011: "https://doi.org/10.1186/1471-2105-12-385"
   desc "Interactively explore metagenomes and more from a web browser"
   homepage "https://github.com/marbl/Krona/wiki"
-  url "https://github.com/marbl/Krona/releases/download/v2.8/KronaTools-2.8.tar"
-  sha256 "56efc028b6226a1aea8ec4e9f049836b07d4833e7e4d5b9189118ed51a47c9c0"
+  url "https://github.com/marbl/Krona/releases/download/v2.8.1/KronaTools-2.8.1.tar"
+  sha256 "f3ab44bf172e1f846e8977c7443d2e0c9676b421b26c50e91fa996d70a6bfd10"
   license "BSD-3-Clause"
 
   bottle do


### PR DESCRIPTION
Bump `krona` to 2.8.1. Detected via `brew livecheck`.