### PR TITLE
legsta 0.5.2

### DIFF
--- a/Formula/legsta.rb
+++ b/Formula/legsta.rb
@@ -1,8 +1,8 @@
 class Legsta < Formula
   desc "In silico Legionella pneumophila Sequence Based Typing"
   homepage "https://github.com/tseemann/legsta"
-  url "https://github.com/tseemann/legsta/archive/refs/tags/v0.5.1.tar.gz"
-  sha256 "a094d0e82af988d5fc2ab0ad9c55c23f7f20d0dd424470a28daf00a59a0190b5"
+  url "https://github.com/tseemann/legsta/archive/refs/tags/v0.5.2.tar.gz"
+  sha256 "73db39cdc695e6a889b0b0092c2eda4119e9fa463e5992e9b5de91186cc97101"
   license "GPL-3.0"
 
   bottle do

--- a/Formula/legsta.rb
+++ b/Formula/legsta.rb
@@ -15,7 +15,7 @@ class Legsta < Formula
   depends_on "ispcr"
 
   def install
-    rm "bin/isPcr" # remove bundled binary
+    rm "bin/isPcr" if File.exist?("bin/isPcr") # remove bundled binary
     prefix.install Dir["*"]
   end
 


### PR DESCRIPTION
Bump `legsta` to 0.5.2. Detected via `brew livecheck`.