### PR TITLE
libcifpp 10.0.4

### DIFF
--- a/Formula/libcifpp.rb
+++ b/Formula/libcifpp.rb
@@ -16,23 +16,25 @@ class Libcifpp < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen" => :build
-  # macOS's std::from_chars lacks floating-point support, so libcifpp's
-  # try_compile fails and it requires fast_float instead.
   depends_on "fast_float" => :build
+  depends_on "boost"
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  on_linux do
-    depends_on "boost"
-  end
-
   def install
+    if OS.mac? && MacOS.version <= :sequoia
+      inreplace "CMakeLists.txt" do |s|
+        s.gsub! "if(NOT STD_CHARCONV_COMPILING)\n\tmessage",
+                "find_package(FastFloat 8.0 QUIET CONFIG)\nif(STD_CHARCONV_COMPILING)\n\tmessage"
+        s.gsub! "PRIVATE $<TARGET_PROPERTY:FastFloat::fast_float,INTERFACE_INCLUDE_DIRECTORIES>",
+                "PRIVATE FastFloat::fast_float"
+      end
+    end
     # The bundled pcre2 is compiled into the shared libcifpp, so it must be
     # position-independent (Linux ld rejects the non-PIC objects otherwise).
     system "cmake", "-S", ".", "-B", "build",
-                    "-DBUILD_SHARED_LIBS=ON",
-                    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+                    "-DCMAKE_CXX_STANDARD=20",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/libcifpp.rb
+++ b/Formula/libcifpp.rb
@@ -16,6 +16,9 @@ class Libcifpp < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen" => :build
+  # macOS's std::from_chars lacks floating-point support, so libcifpp's
+  # try_compile fails and it requires fast_float instead.
+  depends_on "fast_float" => :build
 
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
@@ -25,8 +28,11 @@ class Libcifpp < Formula
   end
 
   def install
+    # The bundled pcre2 is compiled into the shared libcifpp, so it must be
+    # position-independent (Linux ld rejects the non-PIC objects otherwise).
     system "cmake", "-S", ".", "-B", "build",
                     "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/libcifpp.rb
+++ b/Formula/libcifpp.rb
@@ -1,8 +1,8 @@
 class Libcifpp < Formula
   desc "Library containing code to manipulate mmCIF and PDB files"
   homepage "https://pdb-redo.github.io/libcifpp/"
-  url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v8.0.1.tar.gz"
-  sha256 "53f0ff205711428dcabf9451b23804091539303cea9d2f54554199144ca0fc4e"
+  url "https://github.com/PDB-REDO/libcifpp/archive/refs/tags/v10.0.4.tar.gz"
+  sha256 "4ef1386438b5032842c287b0629d5ffc4838d28fa91f384bdc57915dfca8fe9f"
   license "BSD-2-Clause"
   head "https://github.com/PDB-REDO/libcifpp.git", branch: "trunk"
 


### PR DESCRIPTION
Bump `libcifpp` to 10.0.4. Detected via `brew livecheck`.