### PR TITLE
lofreq 2.1.5

### DIFF
--- a/Formula/lofreq.rb
+++ b/Formula/lofreq.rb
@@ -14,39 +14,16 @@ class Lofreq < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "htslib"
   depends_on "python"
 
   uses_from_macos "zlib"
 
-  # Requires to be statically linked against samtools/htslib 1.1
-  # Later versions do not work due to API changes
-  # See: https://github.com/CSB5/lofreq/issues/52
-
-  resource "samtools" do
-    url "https://github.com/samtools/samtools/archive/refs/tags/1.1.tar.gz"
-    sha256 "cee231e33b7290be8e07dea43a99b885d9df79d957625ac84879b47ff91cda69"
-  end
-
-  resource "htslib" do
-    url "https://github.com/samtools/htslib/archive/refs/tags/1.1.tar.gz"
-    sha256 "eb0a7918862336518afcaf62e3d7da8b7f87053fd40d88f2d1ab689f7f25923f"
-  end
+  # Since 2.1.4, lofreq builds against a regular HTSlib installation
+  # (--with-htslib) instead of vendoring a pinned samtools/htslib 1.1 pair.
+  # See the "Changes in 2.1.4" entry in the upstream Changelog.
 
   def install
-    htslib = buildpath/"htslib"
-    resource("htslib").stage do
-      mkdir htslib
-      cp_r ".", htslib
-      system "make", "-C", htslib
-    end
-
-    samtools = buildpath/"samtools"
-    resource("samtools").stage do
-      mkdir samtools
-      cp_r ".", samtools
-      system "make", "-C", samtools, "HTSDIR=#{htslib}"
-    end
-
     system "glibtoolize"
     system "./bootstrap"
     # Skip automake dependency-tracking; its config.status "depfiles" bootstrap
@@ -55,8 +32,7 @@ class Lofreq < Formula
     system "./configure",
            "--disable-dependency-tracking",
            "--prefix=#{prefix}",
-           "SAMTOOLS=#{samtools}",
-           "--with-htslib=#{htslib}"
+           "--with-htslib=#{formula_opt_prefix("htslib")}"
     system "make"
     system "make", "install"
   end

--- a/Formula/lofreq.rb
+++ b/Formula/lofreq.rb
@@ -14,6 +14,9 @@ class Lofreq < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  # setuptools provides the distutils shim removed from Python 3.12+ stdlib,
+  # needed by src/tools/setup.py ("from distutils.core import setup").
+  depends_on "python-setuptools" => :build
   depends_on "htslib"
   depends_on "python"
 

--- a/Formula/lofreq.rb
+++ b/Formula/lofreq.rb
@@ -52,7 +52,7 @@ class Lofreq < Formula
     system "./configure",
            "--prefix=#{prefix}",
            "SAMTOOLS=#{samtools}",
-           "HTSLIB=#{htslib}"
+           "--with-htslib=#{htslib}"
     system "make"
     system "make", "install"
   end

--- a/Formula/lofreq.rb
+++ b/Formula/lofreq.rb
@@ -49,7 +49,11 @@ class Lofreq < Formula
 
     system "glibtoolize"
     system "./bootstrap"
+    # Skip automake dependency-tracking; its config.status "depfiles" bootstrap
+    # fails on Linux ("Something went wrong bootstrapping makefile fragments"),
+    # and it is unneeded for a one-shot build.
     system "./configure",
+           "--disable-dependency-tracking",
            "--prefix=#{prefix}",
            "SAMTOOLS=#{samtools}",
            "--with-htslib=#{htslib}"

--- a/Formula/lofreq.rb
+++ b/Formula/lofreq.rb
@@ -2,8 +2,8 @@ class Lofreq < Formula
   # cite Wilm_2012: "https://10.1093/nar/gks918"
   desc "Low frequency variant calling in populations"
   homepage "https://csb5.github.io/lofreq/"
-  url "https://github.com/CSB5/lofreq/archive/refs/tags/v2.1.3.1.tar.gz"
-  sha256 "72ad0165a226ad8601297d5e01d139574f30d0637c70dec543f8d513c26958eb"
+  url "https://github.com/CSB5/lofreq/archive/refs/tags/v2.1.5.tar.gz"
+  sha256 "da85ec4baca21e20a55b5f9ee491cdda2986d0dc672177007a2c70ca1d804fe7"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"


### PR DESCRIPTION
Bump `lofreq` to 2.1.5. Detected via `brew livecheck`.