### PR TITLE
mash 2.3

### DIFF
--- a/Formula/mash.rb
+++ b/Formula/mash.rb
@@ -4,7 +4,7 @@ class Mash < Formula
   homepage "https://github.com/marbl/Mash"
   url "https://github.com/marbl/Mash/archive/refs/tags/v2.3.tar.gz"
   sha256 "f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1"
-  head "https://github.com/marbl/Mash.git"
+  head "https://github.com/marbl/Mash.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"

--- a/Formula/mash.rb
+++ b/Formula/mash.rb
@@ -23,7 +23,8 @@ class Mash < Formula
   uses_from_macos "zlib"
 
   def install
-    ENV.append "CXXFLAGS", "-include cstdint" # newer GCC needs explicit <cstdint>
+    # newer GCC needs explicit <cstdint> (uintN_t) and <limits> (numeric_limits)
+    ENV.append "CXXFLAGS", "-include cstdint -include limits"
     system "./bootstrap.sh"
     system "./configure",
       "--prefix=#{prefix}",

--- a/Formula/mash.rb
+++ b/Formula/mash.rb
@@ -2,8 +2,8 @@ class Mash < Formula
   # cite Ondov_2016: "https://doi.org/10.1186/s13059-016-0997-x"
   desc "Fast genome distance estimation using MinHash"
   homepage "https://github.com/marbl/Mash"
-  url "https://github.com/marbl/Mash/archive/refs/tags/v2.2.2.tar.gz"
-  sha256 "e4c2d702fd0254f689256b2d8f7d3cc3a68db3ea45b60f0a662ce926a4f5fc22"
+  url "https://github.com/marbl/Mash/archive/refs/tags/v2.3.tar.gz"
+  sha256 "f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1"
   head "https://github.com/marbl/Mash.git"
 
   bottle do

--- a/Formula/mash.rb
+++ b/Formula/mash.rb
@@ -6,12 +6,6 @@ class Mash < Formula
   sha256 "f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1"
   head "https://github.com/marbl/Mash.git", branch: "master"
 
-  bottle do
-    root_url "https://ghcr.io/v2/brewsci/bio"
-    sha256 cellar: :any_skip_relocation, mojave:       "ceded4203723c07f1468254f7f1281031bfd8163e948fb1b165659064f7ef5a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4d75b04ef71f547af960aab06fe485dd53dd830695508fb0f2f33e1cfd5461b9"
-  end
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
@@ -21,6 +15,9 @@ class Mash < Formula
   depends_on "gsl"
 
   uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     # newer GCC needs explicit <cstdint> (uintN_t) and <limits> (numeric_limits)

--- a/Formula/mash.rb
+++ b/Formula/mash.rb
@@ -23,6 +23,7 @@ class Mash < Formula
   uses_from_macos "zlib"
 
   def install
+    ENV.append "CXXFLAGS", "-include cstdint" # newer GCC needs explicit <cstdint>
     system "./bootstrap.sh"
     system "./configure",
       "--prefix=#{prefix}",


### PR DESCRIPTION
Bump `mash` to 2.3. Detected via `brew livecheck`.