### PR TITLE
portcullis 1.2.4

### DIFF
--- a/Formula/portcullis.rb
+++ b/Formula/portcullis.rb
@@ -4,10 +4,9 @@ class Portcullis < Formula
 
   desc "Genuine splice junction prediction from BAM files"
   homepage "https://github.com/maplesond/portcullis"
-  url "https://github.com/maplesond/portcullis/archive/refs/tags/Release-1.1.0.tar.gz"
-  sha256 "872c0dbd7515229ecc22c9bdcd72eb78dfe93a3c0bfd14af52c448c142fe892a"
+  url "https://github.com/maplesond/portcullis/archive/refs/tags/Release-1.2.4.tar.gz"
+  sha256 "9183c4e8108af1e813dbc35e537e16e5d0e13f53ed4c0a36b182c3f8bfcea438"
   license "GPL-3.0"
-  revision 1
   head "https://github.com/maplesond/portcullis.git"
 
   livecheck do

--- a/Formula/portcullis.rb
+++ b/Formula/portcullis.rb
@@ -7,7 +7,7 @@ class Portcullis < Formula
   url "https://github.com/maplesond/portcullis/archive/refs/tags/Release-1.2.4.tar.gz"
   sha256 "9183c4e8108af1e813dbc35e537e16e5d0e13f53ed4c0a36b182c3f8bfcea438"
   license "GPL-3.0"
-  head "https://github.com/maplesond/portcullis.git"
+  head "https://github.com/maplesond/portcullis.git", branch: "develop"
 
   livecheck do
     url :stable

--- a/Formula/portcullis.rb
+++ b/Formula/portcullis.rb
@@ -36,14 +36,16 @@ class Portcullis < Formula
     sha256 "83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6"
   end
 
-  # pandas 0.20.1 (and its matching python-dateutil/pytz/six pins) predates
-  # PEP 517 and needs pkg_resources/distutils, both gone from modern Python
-  # and setuptools, so its build fails on ubuntu-latest. Bumped to the same
-  # pandas/python-dateutil/pytz/six/tzdata combination already proven to
-  # build here in brewsci/bio/eastr.
+  # pandas 0.20.1 (the original pin) predates PEP 517 and needs
+  # pkg_resources/distutils, both gone from modern Python and setuptools.
+  # pandas 2.2.2 in turn fails to compile under Homebrew's default Python
+  # 3.14 because its pinned Cython 3.0.5 emits `[[maybe_unused]]` in the
+  # middle of decl-specifiers, which the newer GCC rejects. pandas 2.3.3 is
+  # the first release with Python 3.14 (cp314) support and an unbounded
+  # Cython pin, so build isolation pulls a Cython that compiles cleanly.
   resource "pandas" do
-    url "https://files.pythonhosted.org/packages/88/d9/ecf715f34c73ccb1d8ceb82fc01cd1028a65a5f6dbc57bfa6ea155119058/pandas-2.2.2.tar.gz"
-    sha256 "9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54"
+    url "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz"
+    sha256 "e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b"
   end
 
   resource "python-dateutil" do

--- a/Formula/portcullis.rb
+++ b/Formula/portcullis.rb
@@ -23,6 +23,8 @@ class Portcullis < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
 
   depends_on "gcc" # for gfortran
   depends_on "numpy"
@@ -34,24 +36,34 @@ class Portcullis < Formula
     sha256 "83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6"
   end
 
+  # pandas 0.20.1 (and its matching python-dateutil/pytz/six pins) predates
+  # PEP 517 and needs pkg_resources/distutils, both gone from modern Python
+  # and setuptools, so its build fails on ubuntu-latest. Bumped to the same
+  # pandas/python-dateutil/pytz/six/tzdata combination already proven to
+  # build here in brewsci/bio/eastr.
   resource "pandas" do
-    url "https://files.pythonhosted.org/packages/34/fd/0cb98ea4df08c82af3de93da5b9f79d573c6ecc05098905f9cd6b0bece51/pandas-0.20.1.tar.gz"
-    sha256 "42707365577ef69f7c9c168ddcf045df2957595a9ee71bc13c7997eecb96b190"
+    url "https://files.pythonhosted.org/packages/88/d9/ecf715f34c73ccb1d8ceb82fc01cd1028a65a5f6dbc57bfa6ea155119058/pandas-2.2.2.tar.gz"
+    sha256 "9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54"
   end
 
   resource "python-dateutil" do
-    url "https://files.pythonhosted.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz"
-    sha256 "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
   end
 
   resource "pytz" do
-    url "https://files.pythonhosted.org/packages/a4/09/c47e57fc9c7062b4e83b075d418800d322caa87ec0ac21e6308bd3a2d519/pytz-2017.2.zip"
-    sha256 "f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589"
+    url "https://files.pythonhosted.org/packages/90/26/9f1f00a5d021fff16dee3de13d43e5e978f3d58928e129c3a62cf7eb9738/pytz-2024.1.tar.gz"
+    sha256 "2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"
   end
 
   resource "six" do
-    url "https://files.pythonhosted.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz"
-    sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+  end
+
+  resource "tzdata" do
+    url "https://files.pythonhosted.org/packages/74/5b/e025d02cb3b66b7b76093404392d4b44343c69101cc85f4d180dd5784717/tzdata-2024.1.tar.gz"
+    sha256 "2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"
   end
 
   def install


### PR DESCRIPTION
Bump `portcullis` to 1.2.4. Detected via `brew livecheck`.