### PR TITLE
r2r 1.0.7

### DIFF
--- a/Formula/r2r.rb
+++ b/Formula/r2r.rb
@@ -2,8 +2,8 @@ class R2r < Formula
   # cite Weinberg_2011: "https://doi.org/10.1186/1471-2105-12-3"
   desc "Software to speed depiction of aesthetic consensus RNA secondary structures"
   homepage "https://sourceforge.net/projects/weinberg-r2r/"
-  url "https://downloads.sourceforge.net/project/weinberg-r2r/R2R-1.0.6.tgz"
-  sha256 "1ba8f51db92866ebe1aeb3c056f17489bceefe2f67c5c0bbdfbddc0eee17743d"
+  url "https://downloads.sourceforge.net/project/weinberg-r2r/R2R-1.0.7.tgz"
+  sha256 "b18d26e27b84d022a59bb5cb33d0670fb5cc6245ce40808b2ef2fc9f8e968b61"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"

--- a/Formula/r2r.rb
+++ b/Formula/r2r.rb
@@ -19,6 +19,10 @@ class R2r < Formula
             "--prefix=#{prefix}"
     system "make", "install"
     doc.install "R2R-manual.pdf"
+    # R2R_Stockholm.pm is a Perl module, not an executable; keep it out of bin
+    libexec.install bin/"R2R_Stockholm.pm"
+    inreplace bin/"SelectSubFamilyFromStockholm.pl",
+              "use lib $Bin;", "use lib \"#{libexec}\";"
   end
 
   test do


### PR DESCRIPTION
Bump `r2r` to 1.0.7. Detected via `brew livecheck`.