### PR TITLE
repaq 0.5.1

### DIFF
--- a/Formula/repaq.rb
+++ b/Formula/repaq.rb
@@ -14,6 +14,7 @@ class Repaq < Formula
   uses_from_macos "zlib"
 
   def install
+    ENV.append "CXXFLAGS", "-include cstdint" # newer GCC needs explicit <cstdint>
     system "make"
     # https://github.com/OpenGene/repaq/issues/6
     bin.mkpath

--- a/Formula/repaq.rb
+++ b/Formula/repaq.rb
@@ -14,7 +14,9 @@ class Repaq < Formula
   uses_from_macos "zlib"
 
   def install
-    ENV.append "CXXFLAGS", "-include cstdint" # newer GCC needs explicit <cstdint>
+    # newer GCC needs an explicit <cstdint>; the Makefile hard-assigns CXXFLAGS
+    # with ":=" so env CXXFLAGS is ignored, patch the assignment directly.
+    inreplace "Makefile", "CXXFLAGS := -std=c++11", "CXXFLAGS := -std=c++11 -include cstdint"
     system "make"
     # https://github.com/OpenGene/repaq/issues/6
     bin.mkpath

--- a/Formula/repaq.rb
+++ b/Formula/repaq.rb
@@ -1,8 +1,8 @@
 class Repaq < Formula
   desc "Repack Illumina format FASTQ to a smaller binary file"
   homepage "https://github.com/OpenGene/repaq"
-  url "https://github.com/OpenGene/repaq/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "60c0a0449d45a3cd346f67cd6db93a961ff7f9d41e787f5c39834d0b1ad3a1bc"
+  url "https://github.com/OpenGene/repaq/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "19720e87ce83327d8c8de6176fa85bb32ada4d722eea86ee5210d2d55cd4e787"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Bump `repaq` to 0.5.1. Detected via `brew livecheck`.