### PR TITLE
rust-sasa 0.9.2

### DIFF
--- a/Formula/rust-sasa.rb
+++ b/Formula/rust-sasa.rb
@@ -1,8 +1,8 @@
 class RustSasa < Formula
   desc "Ludicrously fast CLI for calculating protein SASA written in Rust"
   homepage "https://github.com/maxall41/RustSASA"
-  url "https://github.com/maxall41/RustSASA/archive/refs/tags/v0.7.0.tar.gz"
-  sha256 "649d73e07d67958641f3546f5874534cf13e43a19c1d729ba0e5fad562338bcc"
+  url "https://github.com/maxall41/RustSASA/archive/refs/tags/v0.9.2.tar.gz"
+  sha256 "2f2d7509d2e2bb3a9c1cf79d1b53d6bc1c6de2693ae7d8494a637ab136fadcae"
   license "MIT"
   head "https://github.com/maxall41/RustSASA.git", branch: "main"
 

--- a/Formula/rust-sasa.rb
+++ b/Formula/rust-sasa.rb
@@ -23,15 +23,15 @@ class RustSasa < Formula
 
   def install
     resource("pdbtbx").stage(buildpath/"pdbtbx")
-    system "cargo", "install", *std_cargo_args
-    pkgshare.install "pdbs", "radii"
+    system "cargo", "install", "--features", "cli", *std_cargo_args
+    pkgshare.install "tests/data/pdbs/example.cif"
   end
 
   test do
     assert_match "Usage: rust-sasa [OPTIONS] <INPUT> <OUTPUT>", shell_output("#{bin}/rust-sasa --help")
-    shell_output("#{bin}/rust-sasa #{pkgshare}/pdbs/example.cif #{testpath}/out.json")
+    shell_output("#{bin}/rust-sasa #{pkgshare}/example.cif #{testpath}/out.json")
     assert_path_exists testpath/"out.json"
     output = File.read(testpath/"out.json")
-    assert_match '"value":222.80806,"name":"MET","is_polar":false', output
+    assert_match '"value":220.10417,"name":"MET","is_polar":false', output
   end
 end


### PR DESCRIPTION
Bump `rust-sasa` to 0.9.2. Detected via `brew livecheck`.