### PR TITLE
varscan 2.4.6

### DIFF
--- a/Formula/varscan.rb
+++ b/Formula/varscan.rb
@@ -2,8 +2,8 @@ class Varscan < Formula
   # cite Koboldt_2012: "https://doi.org/10.1101/gr.129684.111"
   desc "Variant detection in massively parallel sequencing data"
   homepage "https://dkoboldt.github.io/varscan/"
-  url "https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.4.jar"
-  sha256 "fb23b72ab676fb5a89bd02091c2b6c9aff210b96bee04d9dee6aef4d8b72814d"
+  url "https://github.com/dkoboldt/varscan/raw/master/VarScan.v2.4.6.jar"
+  sha256 "e827230b47a96cab035c5c7178e5089921a1e1c8d1e4836a6b02ff88e3a4c2ab"
 
   livecheck do
     url "https://github.com/dkoboldt/varscan/tree/master"


### PR DESCRIPTION
Bump `varscan` to 2.4.6. Detected via `brew livecheck`.