### PR TITLE
staden-io-lib 1-16-0

### DIFF
--- a/Formula/staden-io-lib.rb
+++ b/Formula/staden-io-lib.rb
@@ -16,11 +16,11 @@ class StadenIoLib < Formula
   depends_on "htslib"
   depends_on "libdeflate"
   depends_on "xz"
+  depends_on "zlib-ng-compat"
   depends_on "zstd"
 
   uses_from_macos "bzip2"
   uses_from_macos "curl"
-  uses_from_macos "zlib"
 
   resource "htscodecs" do
     url "https://github.com/samtools/htscodecs/archive/5aecc6e107db1c2ff59529a5aa034d28b799b7d1.tar.gz"
@@ -47,16 +47,17 @@ class StadenIoLib < Formula
 
   test do
     (testpath/"test.sam").write <<~EOS
-      @SQ  SN:xx  LN:30
-      a0  16  xx  4  1  10H  *  0  0  *  *
+      @SQ	SN:xx	LN:30
+      a0	16	xx	4	1	10H	*	0	0	*	*
     EOS
 
     (testpath/"test.c").write <<~EOS
       #include "io_lib/scram.h"
       int main(int argc, char** argv) {
-        cram_fd* cramfd = cram_io_open("test.sam","rc","rb");
-        if (CRAM_IO_SEEK(cramfd,0,SEEK_END) == 0) return 0;
-        else return 1;
+        scram_fd* fd = scram_open("test.sam", "r");
+        if (fd == NULL) return 1;
+        scram_close(fd);
+        return 0;
       }
     EOS
 

--- a/Formula/staden-io-lib.rb
+++ b/Formula/staden-io-lib.rb
@@ -3,7 +3,7 @@ class StadenIoLib < Formula
   homepage "https://staden.sourceforge.io/"
   url "https://github.com/jkbonfield/io_lib/archive/refs/tags/io_lib-1-16-0.tar.gz"
   sha256 "2eeb5852378050aa5ca539a8680148f05d7ce52fa9c288224e7a0b698bd97068"
-  head "https://github.com/jkbonfield/io_lib.git"
+  head "https://github.com/jkbonfield/io_lib.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"

--- a/Formula/staden-io-lib.rb
+++ b/Formula/staden-io-lib.rb
@@ -1,8 +1,8 @@
 class StadenIoLib < Formula
   desc "Staden Package io_lib"
   homepage "https://staden.sourceforge.io/"
-  url "https://github.com/jkbonfield/io_lib/archive/refs/tags/io_lib-1-15-0.tar.gz"
-  sha256 "7006ab127ec05649d1f1bceafb7953defc665408da24cf990804d2c65e510f39"
+  url "https://github.com/jkbonfield/io_lib/archive/refs/tags/io_lib-1-16-0.tar.gz"
+  sha256 "2eeb5852378050aa5ca539a8680148f05d7ce52fa9c288224e7a0b698bd97068"
   head "https://github.com/jkbonfield/io_lib.git"
 
   bottle do

--- a/Formula/staden-io-lib.rb
+++ b/Formula/staden-io-lib.rb
@@ -42,10 +42,7 @@ class StadenIoLib < Formula
     pkgshare.install "tests"
 
     # Avoid references to Homebrew shims
-    if OS.linux?
-      inreplace pkgshare/"tests/Makefile", HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/", "/usr/bin/"
-      rm pkgshare/"tests/cram_io_test"
-    end
+    inreplace pkgshare/"tests/Makefile", HOMEBREW_LIBRARY/"Homebrew/shims/linux/super/", "/usr/bin/" if OS.linux?
   end
 
   test do

--- a/Formula/staden-io-lib.rb
+++ b/Formula/staden-io-lib.rb
@@ -13,6 +13,7 @@ class StadenIoLib < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "htslib"
   depends_on "libdeflate"
   depends_on "xz"
   depends_on "zstd"
@@ -34,6 +35,7 @@ class StadenIoLib < Formula
                           "--disable-silent-rules",
                           "--with-libdeflate=#{formula_opt_prefix("libdeflate")}",
                           "--with-zstd=#{formula_opt_prefix("zstd")}",
+                          "--with-htslib=#{formula_opt_prefix("htslib")}",
                           "--prefix=#{prefix}"
     system "make", "install"
 


### PR DESCRIPTION
Bump `staden-io-lib` to 1-16-0. Detected via `brew livecheck`.