### PR TITLE
raven-assembler 1.8.3

### DIFF
--- a/Formula/raven-assembler.rb
+++ b/Formula/raven-assembler.rb
@@ -17,7 +17,7 @@ class RavenAssembler < Formula
     # cereal (fetched via FetchContent) still declares cmake_minimum_required < 3.5
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", "-DRAVEN_BUILD_EXE=ON", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/raven-assembler.rb
+++ b/Formula/raven-assembler.rb
@@ -14,6 +14,8 @@ class RavenAssembler < Formula
   depends_on "cmake" => :build
 
   def install
+    # cereal (fetched via FetchContent) still declares cmake_minimum_required < 3.5
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make"

--- a/Formula/raven-assembler.rb
+++ b/Formula/raven-assembler.rb
@@ -1,8 +1,8 @@
 class RavenAssembler < Formula
   desc "De novo DNA assembly of long uncorrected read"
   homepage "https://github.com/lbcb-sci/raven"
-  url "https://github.com/lbcb-sci/raven/releases/download/0.0.0/raven-v0.0.0.tar.gz"
-  sha256 "6ca62a0152e130216da2959099ca152aa21d6758770b74c430f515ff755c1b2d"
+  url "https://github.com/lbcb-sci/raven/archive/refs/tags/1.8.3.tar.gz"
+  sha256 "5e7725d1115f7bbd2b6e72d3eb813e99beee552abdb751050d092de2348e5439"
   license "MIT"
 
   bottle do

--- a/Formula/raven-assembler.rb
+++ b/Formula/raven-assembler.rb
@@ -13,11 +13,21 @@ class RavenAssembler < Formula
 
   depends_on "cmake" => :build
 
+  uses_from_macos "zlib"
+
+  # The raven binary links libz (via bioparser/racon); on Linux use the brewed
+  # zlib-ng-compat so linkage isn't flagged against the host system libz.
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
   def install
     # cereal (fetched via FetchContent) still declares cmake_minimum_required < 3.5
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
+    args = ["-DRAVEN_BUILD_EXE=ON"]
+    args << "-DZLIB_ROOT=#{formula_opt_prefix("zlib-ng-compat")}" if OS.linux?
     mkdir "build" do
-      system "cmake", "..", "-DRAVEN_BUILD_EXE=ON", *std_cmake_args
+      system "cmake", "..", *args, *std_cmake_args
       system "make"
       system "make", "install"
     end


### PR DESCRIPTION
Bump `raven-assembler` to 1.8.3. Detected via `brew livecheck`.