### PR TITLE
k8 1.2

### DIFF
--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -20,20 +20,22 @@ class K8 < Formula
     # The bundled Linux binary is dynamically linked against libz and would
     # otherwise resolve to the host's /lib, failing `brew linkage --test`.
     # zlib-ng-compat provides libz.so.1 so it resolves to the brewed copy.
-    depends_on "zlib-ng-compat"
+    depends_on "zlib-ng-compat" # provides libz.so.1
   end
 
   def install
     exe = OS.mac? ? "k8-#{Hardware::CPU.arch}-Darwin" : "k8-#{Hardware::CPU.arch}-Linux"
     bin.install exe => "k8"
     if OS.linux?
-      # The prebuilt binary is NEEDED libz.so.1; point its rpath at the
-      # keg-only zlib-ng-compat lib so `brew linkage --test` resolves the
-      # brewed libz instead of the host's /lib/x86_64-linux-gnu/libz.so.1.
-      system "patchelf",
-             "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
-             "--set-rpath", "#{formula_opt_lib("zlib-ng-compat")}:#{HOMEBREW_PREFIX}/lib",
-             bin/"k8"
+      # The prebuilt binary is NEEDED libz.so.1. Symlink the brewed
+      # zlib-ng-compat copy into our own keg and point the rpath at it with a
+      # relative $ORIGIN entry. This satisfies `brew linkage --test` without
+      # leaving any HOMEBREW_PREFIX path in the ELF, so `brew bottle` skips its
+      # rpath relocation entirely. That relocation runs the vendored
+      # patchelf.rb, which crashes (split_index) on this binary's segment
+      # layout; every absolute-rpath variant hit that bug.
+      lib.install_symlink formula_opt_lib("zlib-ng-compat")/"libz.so.1"
+      system "patchelf", "--set-rpath", "$ORIGIN/../lib", bin/"k8"
     end
     pkgshare.install "scripts/k8.js"
   end

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -27,10 +27,13 @@ class K8 < Formula
     exe = OS.mac? ? "k8-#{Hardware::CPU.arch}-Darwin" : "k8-#{Hardware::CPU.arch}-Linux"
     bin.install exe => "k8"
     if OS.linux?
+      # The prebuilt binary is NEEDED libz.so.1; point its rpath at the
+      # keg-only zlib-ng-compat lib so `brew linkage --test` resolves the
+      # brewed libz instead of the host's /lib/x86_64-linux-gnu/libz.so.1.
       system "patchelf",
-        "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
-        "--set-rpath", HOMEBREW_PREFIX/"lib",
-        bin/"k8"
+             "--set-interpreter", HOMEBREW_PREFIX/"lib/ld.so",
+             "--set-rpath", "#{formula_opt_lib("zlib-ng-compat")}:#{HOMEBREW_PREFIX}/lib",
+             bin/"k8"
     end
     pkgshare.install "scripts/k8.js"
   end

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -21,7 +21,7 @@ class K8 < Formula
   end
 
   def install
-    exe = OS.mac? ? "k8-Darwin" : "k8-Linux"
+    exe = OS.mac? ? "k8-#{Hardware::CPU.arch}-Darwin" : "k8-#{Hardware::CPU.arch}-Linux"
     bin.install exe => "k8"
     if OS.linux?
       system "patchelf",
@@ -29,7 +29,7 @@ class K8 < Formula
         "--set-rpath", HOMEBREW_PREFIX/"lib",
         bin/"k8"
     end
-    pkgshare.install "k8.js"
+    pkgshare.install "scripts/k8.js"
   end
 
   test do

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -17,7 +17,10 @@ class K8 < Formula
 
   unless OS.mac?
     depends_on "patchelf" => :build
-    depends_on "zlib"
+    # The bundled Linux binary is dynamically linked against libz and would
+    # otherwise resolve to the host's /lib, failing `brew linkage --test`.
+    # zlib-ng-compat provides libz.so.1 so it resolves to the brewed copy.
+    depends_on "zlib-ng-compat"
   end
 
   def install

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -1,8 +1,8 @@
 class K8 < Formula
   desc "Javascript shell based on Google's V8 Javascript engine"
   homepage "https://github.com/attractivechaos/k8"
-  url "https://github.com/attractivechaos/k8/releases/download/0.2.5/k8-0.2.5.tar.bz2"
-  sha256 "a937ac44532e042cd89ac743647b592c21cfcf31679e39e5f362e81034d93d18"
+  url "https://github.com/attractivechaos/k8/releases/download/v1.2/k8-1.2.tar.bz2"
+  sha256 "a86b160a82f3233a21235d21170f3719a600dbd96bf1ec705a6eb57d770953c9"
 
   livecheck do
     url :stable

--- a/Formula/k8.rb
+++ b/Formula/k8.rb
@@ -28,14 +28,16 @@ class K8 < Formula
     bin.install exe => "k8"
     if OS.linux?
       # The prebuilt binary is NEEDED libz.so.1. Symlink the brewed
-      # zlib-ng-compat copy into our own keg and point the rpath at it with a
-      # relative $ORIGIN entry. This satisfies `brew linkage --test` without
-      # leaving any HOMEBREW_PREFIX path in the ELF, so `brew bottle` skips its
-      # rpath relocation entirely. That relocation runs the vendored
-      # patchelf.rb, which crashes (split_index) on this binary's segment
-      # layout; every absolute-rpath variant hit that bug.
-      lib.install_symlink formula_opt_lib("zlib-ng-compat")/"libz.so.1"
-      system "patchelf", "--set-rpath", "$ORIGIN/../lib", bin/"k8"
+      # zlib-ng-compat copy into libexec (which, unlike lib, is not linked into
+      # the shared prefix, so it cannot collide with zlib-ng-compat's own
+      # libz.so.1) and point the rpath at it with a relative $ORIGIN entry.
+      # This satisfies `brew linkage --test` without leaving any
+      # HOMEBREW_PREFIX path in the ELF, so `brew bottle` skips its rpath
+      # relocation entirely. That relocation runs the vendored patchelf.rb,
+      # which crashes (split_index) on this binary's segment layout; every
+      # absolute-rpath variant hit that bug.
+      (libexec/"lib").install_symlink formula_opt_lib("zlib-ng-compat")/"libz.so.1"
+      system "patchelf", "--set-rpath", "$ORIGIN/../libexec/lib", bin/"k8"
     end
     pkgshare.install "scripts/k8.js"
   end


### PR DESCRIPTION
Bump `k8` to 1.2. Detected via `brew livecheck`.