### PR TITLE
vep, viennarna: fix livecheck to avoid false-positive autobumps

### DIFF
--- a/Formula/vep.rb
+++ b/Formula/vep.rb
@@ -7,9 +7,11 @@ class Vep < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/Ensembl/ensembl-vep.git"
-    strategy :git
-    regex(%r{^release/(\d+(?:\.\d+)+)$}i)
+    # Use published releases (not raw tags): the repo carries stray tags like
+    # release/162.2 and release/167.0 that are not real VEP releases.
+    url :stable
+    strategy :github_latest
+    regex(%r{release[/-]v?(\d+(?:\.\d+)+)}i)
   end
 
   bottle do

--- a/Formula/viennarna.rb
+++ b/Formula/viennarna.rb
@@ -7,6 +7,13 @@ class Viennarna < Formula
   license :cannot_represent
   head "https://github.com/ViennaRNA/ViennaRNA.git", branch: "master"
 
+  # The tbi.univie.ac.at download URL is not version-parseable; track GitHub releases.
+  livecheck do
+    url :head
+    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"
     sha256 cellar: :any,                 arm64_tahoe:   "2b017598f54a2e323fecd916e083afb374a574b644eeb673f2764eb990b6de34"


### PR DESCRIPTION
The autobump kept detecting bogus versions:
- `vep`: `strategy :git` matched stray non-release tags (release/162.2, release/167.0); switched to `:github_latest` so only published releases count (currently release/116.0).
- `viennarna`: had no livecheck; the tbi.univie.ac.at URL isn't version-parseable, so livecheck misread "14". Added a GitHub-releases livecheck (now correctly finds 2.7.2).

Verified with `brew livecheck`: vep 116.0 (up to date), viennarna 2.7.0 => 2.7.2.