### PR TITLE
autobump: fix shellcheck SC2086 breaking tap-syntax on every PR

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -75,7 +75,8 @@ jobs:
           set -o pipefail
           BUMP=(brew bump --tap brewsci/bio --formulae --open-pr)
           if [[ -n "${FORMULAE-}" ]]; then
-            "${BUMP[@]}" ${FORMULAE} 2>&1 | tee bump.log || true
+            read -ra FLIST <<<"${FORMULAE}"
+            "${BUMP[@]}" "${FLIST[@]}" 2>&1 | tee bump.log || true
           else
             "${BUMP[@]}" 2>&1 | tee bump.log || true
           fi


### PR DESCRIPTION
#2225 was a workflow-only PR so it skipped build-bottles CI, and a shellcheck issue slipped in: the `${FORMULAE}` expansion at autobump.yml:74 is unquoted (SC2086). This makes the whole-tap `brew style brewsci/bio` (run in every PR's tap-syntax step) fail, so **all open PRs currently fail CI after ~1 min**. Fix: read the dispatch input into an array and quote it.