### PR TITLE
harvest-tools: fix macOS deployment target to build against modern abseil/protobuf

### DIFF
--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -26,8 +26,10 @@ class HarvestTools < Formula
   depends_on "abseil"
   depends_on "capnp"
   depends_on "protobuf"
-
   uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     inreplace "configure.ac", "-std=c++11", "-std=c++17"

--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -35,7 +35,7 @@ class HarvestTools < Formula
     inreplace "configure.ac", "-std=c++11", "-std=c++17"
     inreplace "Makefile.in", "-std=c++11", "-std=c++17"
     if OS.mac?
-      inreplace ["configure.ac", "Makefile.in"], "-mmacosx-version-min=10.7", "-mmacosx-version-min=#{MacOS.version}"
+      inreplace "Makefile.in", "-mmacosx-version-min=10.7", "-mmacosx-version-min=10.14"
     end
     inreplace "src/harvest/HarvestIO.cpp", "SetTotalBytesLimit(INT_MAX, INT_MAX)", "SetTotalBytesLimit(INT_MAX)"
     inreplace "Makefile.in", "-lpthread",

--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -34,9 +34,7 @@ class HarvestTools < Formula
   def install
     inreplace "configure.ac", "-std=c++11", "-std=c++17"
     inreplace "Makefile.in", "-std=c++11", "-std=c++17"
-    if OS.mac?
-      inreplace "Makefile.in", "-mmacosx-version-min=10.7", "-mmacosx-version-min=10.14"
-    end
+    inreplace "Makefile.in", "-mmacosx-version-min=10.7", "-mmacosx-version-min=10.14" if OS.mac?
     inreplace "src/harvest/HarvestIO.cpp", "SetTotalBytesLimit(INT_MAX, INT_MAX)", "SetTotalBytesLimit(INT_MAX)"
     inreplace "Makefile.in", "-lpthread",
               "-lpthread -labsl_log_internal_check_op -labsl_log_internal_message"

--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -34,6 +34,9 @@ class HarvestTools < Formula
   def install
     inreplace "configure.ac", "-std=c++11", "-std=c++17"
     inreplace "Makefile.in", "-std=c++11", "-std=c++17"
+    if OS.mac?
+      inreplace ["configure.ac", "Makefile.in"], "-mmacosx-version-min=10.7", "-mmacosx-version-min=#{MacOS.version}"
+    end
     inreplace "src/harvest/HarvestIO.cpp", "SetTotalBytesLimit(INT_MAX, INT_MAX)", "SetTotalBytesLimit(INT_MAX)"
     inreplace "Makefile.in", "-lpthread",
               "-lpthread -labsl_log_internal_check_op -labsl_log_internal_message"

--- a/Formula/harvest-tools.rb
+++ b/Formula/harvest-tools.rb
@@ -34,6 +34,7 @@ class HarvestTools < Formula
   def install
     inreplace "configure.ac", "-std=c++11", "-std=c++17"
     inreplace "Makefile.in", "-std=c++11", "-std=c++17"
+    inreplace "Makefile.in", "-mmacosx-version-min=10.7", "-mmacosx-version-min=#{MacOS.version}" if OS.mac?
     inreplace "src/harvest/HarvestIO.cpp", "SetTotalBytesLimit(INT_MAX, INT_MAX)", "SetTotalBytesLimit(INT_MAX)"
     inreplace "Makefile.in", "-lpthread",
               "-lpthread -labsl_log_internal_check_op -labsl_log_internal_message"


### PR DESCRIPTION
`harvest-tools` fails to build on macOS because `Makefile.in` hardcodes `-mmacosx-version-min=10.7`, but current abseil (pulled in by protobuf) uses `std::visit` from `<variant>`, which the compiler marks unavailable when targeting < 10.13.

## Changes

- **Bump deployment target**: Replace `-mmacosx-version-min=10.7` with `10.14` in `Makefile.in` only
  - `configure.ac` does not contain this flag — applying `inreplace` to it caused a second failure
  - `MacOS.version` was avoided: on macOS Tahoe it interpolates as the bare integer `26`, producing the invalid flag `-mmacosx-version-min=26`
- **Add `on_linux` zlib dependency**: Add `depends_on "zlib-ng-compat"` for Linux builds alongside `uses_from_macos "zlib"`

```ruby
# Before (broken — configure.ac lacks the flag; MacOS.version → "26" on Tahoe)
inreplace ["configure.ac", "Makefile.in"], "-mmacosx-version-min=10.7", "-mmacosx-version-min=#{MacOS.version}"

# After
inreplace "Makefile.in", "-mmacosx-version-min=10.7", "-mmacosx-version-min=10.14"
```