### PR TITLE
star-aligner: fix 0 input reads on macOS

### DIFF
--- a/Formula/star-aligner.rb
+++ b/Formula/star-aligner.rb
@@ -6,6 +6,7 @@ class StarAligner < Formula
   version "2.7.11b"
   sha256 "3f65305e4112bd154c7e22b333dcdaafc681f4a895048fa30fa7ae56cac408e7"
   license "MIT"
+  revision 1
   head "https://github.com/alexdobin/STAR.git"
 
   bottle do
@@ -21,11 +22,23 @@ class StarAligner < Formula
     depends_on "libomp"
   end
 
+  # Fix STAR reporting 0 input reads on macOS (libc++ ignores setbuf).
+  # https://github.com/alexdobin/STAR/pull/2691
+  patch do
+    url "https://github.com/alexdobin/STAR/commit/14b1f235927e75ff927be08134c1fb6a00c14d79.patch?full_index=1"
+    sha256 "f12a27b4f1381b591011de118f715bd93ea32e87d26c60f13aa246f67191d9db"
+  end
+
   def install
     cd "source" do
       if OS.mac?
         inreplace "Makefile", "-static-libgcc", ""
-        system "make", "STARforMacStatic", "STARlongForMacStatic"
+        args = ["STARforMacStatic", "STARlongForMacStatic"]
+        # opal bundles SIMDe, which lowers its AVX2 intrinsics to NEON on Apple
+        # Silicon; the Makefile's default -mavx2 is x86-only and a hard error
+        # under clang on arm64.
+        args.unshift "CXXFLAGS_SIMD=" if Hardware::CPU.arm?
+        system "make", *args
       else
         system "make", "STAR", "STARlong"
       end
@@ -37,5 +50,33 @@ class StarAligner < Formula
   test do
     assert_match "Usage:", shell_output("#{bin}/STAR --help")
     assert_match "Usage:", shell_output("#{bin}/STARlong --help")
+
+    # Build a tiny genome, derive one read from it, and confirm STAR actually
+    # ingests the read. Guards against the macOS libc++ setbuf bug (STAR
+    # PR #2691) where STAR ran with exit 0 but reported 0 input reads.
+    bases = "ACGT"
+    lcg = 1
+    genome = +""
+    2000.times do
+      lcg = ((1_103_515_245 * lcg) + 12_345) & 0x7fffffff
+      genome << bases[(lcg >> 16) & 3]
+    end
+    (testpath/"ref.fa").write ">chr1\n#{genome}\n"
+
+    read = genome[500, 50]
+    (testpath/"reads.fq").write "@r1\n#{read}\n+\n#{"I" * read.length}\n"
+
+    (testpath/"genome").mkpath
+    system bin/"STAR", "--runMode", "genomeGenerate", "--genomeDir", "genome",
+           "--genomeFastaFiles", "ref.fa", "--genomeSAindexNbases", "4",
+           "--runThreadN", "1"
+    system bin/"STAR", "--runMode", "alignReads", "--genomeDir", "genome",
+           "--readFilesIn", "reads.fq", "--outFileNamePrefix", "out_",
+           "--runThreadN", "1"
+
+    input_reads = (testpath/"out_Log.final.out").read[/Number of input reads\s*\|\s*(\d+)/, 1]
+    assert_equal "1", input_reads,
+                 "STAR reported #{input_reads.inspect} input reads; the macOS " \
+                 "libc++ setbuf bug (STAR PR #2691) is present"
   end
 end

--- a/Formula/star-aligner.rb
+++ b/Formula/star-aligner.rb
@@ -7,7 +7,7 @@ class StarAligner < Formula
   sha256 "3f65305e4112bd154c7e22b333dcdaafc681f4a895048fa30fa7ae56cac408e7"
   license "MIT"
   revision 1
-  head "https://github.com/alexdobin/STAR.git"
+  head "https://github.com/alexdobin/STAR.git", branch: "master"
 
   bottle do
     root_url "https://ghcr.io/v2/brewsci/bio"


### PR DESCRIPTION
## Problem

On macOS/Apple Silicon, `star-aligner` runs with **exit 0**, logs
`finished successfully`, but silently reports `Number of input reads = 0`
and writes an empty SAM/BAM. Nothing in the log or exit status signals the
failure.

Root cause: STAR reads input and writes SAM/BAM records zero-copy through
pre-allocated char buffers via `stringStream.rdbuf()->pubsetbuf(buf, size)`
in `source/ReadAlignChunk.cpp`. `std::basic_stringbuf::setbuf` is
**implementation-defined**: libstdc++ (Linux/GCC) adopts the external
buffer, but libc++ (clang/macOS) ignores it, so the streams stay empty.
Linux is unaffected.

The old test only ran `STAR --help`, so it never caught this.

## Fix

- **Apply the upstream patch** [alexdobin/STAR#2691](https://github.com/alexdobin/STAR/pull/2691)
  (commit `14b1f235`), which replaces the non-portable `pubsetbuf` idiom
  with an explicit `ExtBufStreambuf`. Behaviour is now identical on libc++
  and libstdc++, and zero-copy is preserved.
- **`revision 1`** so existing installs pick up the rebuilt binary via
  `brew upgrade` (the outdated check compares version+revision).
- **Strengthen the test**: build a tiny genome, derive one read from it,
  run `genomeGenerate` then `alignReads`, and assert a non-zero
  `Number of input reads` in `Log.final.out`. This fails on the unpatched
  macOS binary and passes once patched.

### Also: Apple Silicon build fix (prerequisite)

The bundled `opal` SIMD library's Makefile hardcodes the x86-only `-mavx2`
flag (`CXXFLAGS_SIMD ?= -mavx2`). Recent clang on arm64 rejects it as a
hard error (`unsupported option '-mavx2' for target 'arm64'`), so the
current formula no longer builds on modern Apple Silicon toolchains.
`opal` bundles **SIMDe**, which lowers its AVX2 intrinsics to NEON, so the
flag is unnecessary on arm64. The formula now drops `-mavx2` there
(`CXXFLAGS_SIMD=` on `Hardware::CPU.arm?`); x86 and Linux are unchanged.

## Verification (local, macOS arm64, clang 21)

Red/green with the new test:

| Build | `Number of input reads` | new test |
|-------|-------------------------|----------|
| unpatched | `0` | **fails** |
| patched (this PR) | `1` (uniquely mapped, 100%) | **passes** |

- `brew install --build-from-source brewsci/bio/star-aligner` succeeds
- `brew test brewsci/bio/star-aligner` exits 0
- `brew style` and `brew audit --strict brewsci/bio/star-aligner` pass

Linux behaviour is unchanged: the patched code path is identical there,
and the `-mavx2` handling only affects the Apple Silicon branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
