### PR TITLE
interop 1.9.0 (new formula)

### DIFF
--- a/Formula/interop.rb
+++ b/Formula/interop.rb
@@ -1,0 +1,38 @@
+class Interop < Formula
+  desc "Parse Illumina InterOp sequencing run-metrics files"
+  homepage "https://github.com/Illumina/interop"
+  url "https://github.com/Illumina/interop/archive/refs/tags/v1.9.0.tar.gz"
+  sha256 "55d153bd0e97540907d816921823ac03cf2e38f78d44eecf977dac8c0e8a299f"
+  license "GPL-3.0-only"
+  head "https://github.com/Illumina/interop.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "cmake" => :build
+
+  def install
+    apps = %w[
+      aggregate dumpbin dumptext imaging_table index-summary
+      plot_by_cycle plot_by_lane plot_flowcell plot_qscore_heatmap
+      plot_qscore_histogram plot_sample_qc summary
+    ]
+    args = %w[
+      -DENABLE_SWIG=OFF -DENABLE_CSHARP=OFF -DENABLE_PYTHON=OFF
+      -DENABLE_TEST=OFF -DENABLE_DOCS=OFF -DENABLE_EXAMPLES=OFF
+      -DENABLE_DEPENDENCY_MANAGER=OFF
+    ]
+    # Upstream forces a universal "x86_64;arm64" build on macOS; pin to native.
+    args << "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.arch}" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build", "--target", *apps
+    apps.each { |app| bin.install "build/src/apps/#{app}" }
+  end
+
+  test do
+    assert_match "Usage: summary", shell_output("#{bin}/summary --help")
+  end
+end


### PR DESCRIPTION
New formula for [Illumina InterOp](https://github.com/Illumina/interop).

C++ command-line tools to parse Illumina InterOp files (the binary run-metrics
emitted by Illumina sequencers), producing run summaries, imaging tables and
plot data (`summary`, `dumptext`, `index-summary`, `plot_*`, etc.).

- Packaged from the `v1.9.0` release tarball, which ships under **GPL-3.0**.
- Builds the C++ command-line apps only (SWIG / C# / Python / test / docs
  bindings disabled). Upstream forces a universal `x86_64;arm64` macOS build,
  which is pinned to the native arch in the formula.

### Checklist
- [x] `brew install --build-from-source interop`
- [x] `brew test interop`
- [x] `brew audit --new --strict interop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)