### PR TITLE
gargs 0.3.9 (new formula)

### DIFF
--- a/Formula/gargs.rb
+++ b/Formula/gargs.rb
@@ -1,0 +1,22 @@
+class Gargs < Formula
+  desc "Better(?) xargs in Go: run commands in parallel with templating"
+  homepage "https://github.com/brentp/gargs"
+  url "https://github.com/brentp/gargs/archive/refs/tags/v0.3.9.tar.gz"
+  sha256 "635dbaa6def7438240032a6ea70ae0f2249868d50df17e16bfd564591e30692c"
+  license "Apache-2.0"
+  head "https://github.com/brentp/gargs.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    # Upstream predates Go modules; initialise one so the build resolves deps.
+    system "go", "mod", "init", "github.com/brentp/gargs"
+    system "go", "mod", "tidy"
+    system "go", "build", *std_go_args(output: bin/"gargs"), "."
+  end
+
+  test do
+    output = pipe_output("#{bin}/gargs -p 2 'echo hello {}'", "world\n")
+    assert_match "hello world", output
+  end
+end


### PR DESCRIPTION
New formula for [gargs](https://github.com/brentp/gargs) by Brent Pedersen.

A better(?) `xargs` written in Go: run commands in parallel with convenient
per-argument templating (`{}`, `{0}`, `{1}`, ...). Apache-2.0.

Upstream predates Go modules, so the formula initialises a module at build
time to resolve dependencies.

### Checklist
- [x] `brew install --build-from-source gargs`
- [x] `brew test gargs`
- [x] `brew audit --new --strict gargs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)