### PR TITLE
akt 0.3.3 (new formula)

### DIFF
--- a/Formula/akt.rb
+++ b/Formula/akt.rb
@@ -1,0 +1,42 @@
+class Akt < Formula
+  desc "Ancestry and Kinship Tools for population-scale sequencing data"
+  homepage "https://github.com/Illumina/akt"
+  url "https://github.com/Illumina/akt/archive/refs/tags/v0.3.3.tar.gz"
+  sha256 "1b077dde944cb13132e4fb5b47d4930c1ecfc74b299c95fe3cc7bf5c17b8f710"
+  license "GPL-3.0-only"
+  head "https://github.com/Illumina/akt.git", branch: "master"
+
+  depends_on "eigen" => :build
+  depends_on "htslib"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "curl"
+  uses_from_macos "xz"
+  uses_from_macos "zlib"
+
+  def install
+    eigen = "#{formula_opt_include("eigen")}/eigen3"
+    # Build against Homebrew's htslib and a modern Eigen rather than the
+    # bundled copies (htslib is a submodule absent from the release tarball;
+    # the vendored Eigen predates modern Clang). Eigen 3.4 requires C++14.
+    rm_r "Eigen"
+    inreplace "Makefile" do |s|
+      s.gsub! "include $(HTSDIR)/htslib.mk\n", ""
+      s.gsub! "IFLAGS = -I$(HTSDIR)  -I./",
+              "IFLAGS = -I#{formula_opt_include("htslib")} -I#{eigen} -I./"
+      s.gsub! "HTSLIB = $(HTSDIR)/libhts.a", "HTSLIB = -L#{formula_opt_lib("htslib")} -lhts"
+      s.gsub! "akt: akt.cpp version.hh $(OBJS) $(HTSLIB)", "akt: akt.cpp version.hh $(OBJS)"
+      s.gsub! "LFLAGS = -lz -lm  -lpthread", "LFLAGS = -lz -lm -lpthread -lbz2 -llzma -lcurl"
+      s.gsub! "-std=c++11", "-std=c++14"
+    end
+
+    # `no_omp` drops -fopenmp and the x86-only -mpopcnt flag.
+    system "make", "no_omp", "CXX=#{ENV.cxx}", "CC=#{ENV.cc}"
+    bin.install "akt"
+  end
+
+  test do
+    assert_match "Ancestry and Kinship Tools", shell_output("#{bin}/akt 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/akt 2>&1", 1)
+  end
+end

--- a/Formula/akt.rb
+++ b/Formula/akt.rb
@@ -9,9 +9,6 @@ class Akt < Formula
   depends_on "eigen" => :build
   depends_on "htslib"
 
-  uses_from_macos "bzip2"
-  uses_from_macos "curl"
-  uses_from_macos "xz"
   uses_from_macos "zlib"
 
   def install
@@ -26,7 +23,6 @@ class Akt < Formula
               "IFLAGS = -I#{formula_opt_include("htslib")} -I#{eigen} -I./"
       s.gsub! "HTSLIB = $(HTSDIR)/libhts.a", "HTSLIB = -L#{formula_opt_lib("htslib")} -lhts"
       s.gsub! "akt: akt.cpp version.hh $(OBJS) $(HTSLIB)", "akt: akt.cpp version.hh $(OBJS)"
-      s.gsub! "LFLAGS = -lz -lm  -lpthread", "LFLAGS = -lz -lm -lpthread -lbz2 -llzma -lcurl"
       s.gsub! "-std=c++11", "-std=c++14"
     end
 


### PR DESCRIPTION
New formula for [akt](https://github.com/Illumina/akt) (Ancestry and Kinship Tools) by Illumina.

Population-scale tools operating on VCF/BCF: principal component analysis,
kinship/relatedness coefficients, pedigree discovery, unrelated-sample
selection and Mendelian transmission phasing (`pca`, `kin`, `relatives`,
`unrelated`, `pedphase`).

Packaged from the **v0.3.3** release tarball, which is distributed under
**GPL-3.0**. Build notes:
- The bundled htslib is a git submodule (absent from the release tarball) and
  the vendored Eigen predates modern Clang, so the formula builds against
  Homebrew's `htslib` and `eigen`. Eigen 3.4 requires C++14 (bumped from C++11).
- Uses the `no_omp` target, dropping `-fopenmp` and the x86-only `-mpopcnt`
  flag so it builds on Apple Silicon.

### Checklist
- [x] `brew install --build-from-source akt`
- [x] `brew test akt`
- [x] `brew audit --new --strict akt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)