### PR TITLE
gvcfgenotyper 2019.02.26 (new formula)

### DIFF
--- a/Formula/gvcfgenotyper.rb
+++ b/Formula/gvcfgenotyper.rb
@@ -8,8 +8,6 @@ class Gvcfgenotyper < Formula
 
   depends_on "htslib"
 
-  uses_from_macos "bzip2"
-  uses_from_macos "xz"
   uses_from_macos "zlib"
 
   def install
@@ -25,6 +23,8 @@ class Gvcfgenotyper < Formula
       s.gsub! "HTSLIB = $(HTSDIR)/libhts.a", "HTSLIB = -L#{formula_opt_lib("htslib")} -lhts"
       s.gsub! "bin/gvcfgenotyper: src/cpp/gvcfgenotyper.cpp  $(OBJS) $(HTSLIB)",
               "bin/gvcfgenotyper: src/cpp/gvcfgenotyper.cpp $(OBJS)"
+      # Don't link htslib's transitive libs directly (fails `brew linkage`).
+      s.gsub! "LFLAGS = -lz -lm -lpthread -llzma -lbz2", "LFLAGS = -lz -lm -lpthread"
     end
 
     system "make", "bin/gvcfgenotyper", "CXX=#{ENV.cxx}", "CC=#{ENV.cc}"

--- a/Formula/gvcfgenotyper.rb
+++ b/Formula/gvcfgenotyper.rb
@@ -1,0 +1,38 @@
+class Gvcfgenotyper < Formula
+  desc "Merge and genotype Illumina-style gVCFs"
+  homepage "https://github.com/Illumina/gvcfgenotyper"
+  url "https://github.com/Illumina/gvcfgenotyper/archive/refs/tags/2019.02.26.tar.gz"
+  sha256 "9f2e812fa8873aa668514332aa040734d5fbb9321af06451805be559e956cb96"
+  license "Apache-2.0"
+  head "https://github.com/Illumina/gvcfgenotyper.git", branch: "master"
+
+  depends_on "htslib"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "xz"
+  uses_from_macos "zlib"
+
+  def install
+    mkdir "build"
+    mkdir "bin"
+    # Build against Homebrew's htslib (the bundled htslib is a prebuilt Linux
+    # archive; its vendored bcftools code compiles cleanly against modern
+    # htslib). Only build the tool, not the gtest-based test binary.
+    inreplace "Makefile" do |s|
+      s.gsub! "include external/googletest-release-1.8.0//googletest/make/Makefile\n", ""
+      s.gsub! "include $(HTSDIR)/htslib.mk\n", ""
+      s.gsub! "HTSDIR=external/htslib-1.9", "HTSDIR=#{formula_opt_include("htslib")}"
+      s.gsub! "HTSLIB = $(HTSDIR)/libhts.a", "HTSLIB = -L#{formula_opt_lib("htslib")} -lhts"
+      s.gsub! "bin/gvcfgenotyper: src/cpp/gvcfgenotyper.cpp  $(OBJS) $(HTSLIB)",
+              "bin/gvcfgenotyper: src/cpp/gvcfgenotyper.cpp $(OBJS)"
+    end
+
+    system "make", "bin/gvcfgenotyper", "CXX=#{ENV.cxx}", "CC=#{ENV.cc}"
+    bin.install "bin/gvcfgenotyper"
+  end
+
+  test do
+    assert_match "GVCF merging and genotyping", shell_output("#{bin}/gvcfgenotyper 2>&1", 1)
+    assert_match version.to_s, shell_output("#{bin}/gvcfgenotyper 2>&1", 1)
+  end
+end


### PR DESCRIPTION
New formula for [gvcfgenotyper](https://github.com/Illumina/gvcfgenotyper) by Illumina.

A utility for merging and genotyping Illumina-style gVCFs into a multi-sample
VCF/BCF — a common step in population gVCF workflows.

Packaged from the **2019.02.26** tag (**Apache-2.0**). Build notes:
- The bundled `htslib` is a prebuilt Linux archive that macOS `ld` rejects, so
  the formula builds against Homebrew's `htslib`; the vendored bcftools-derived
  code compiles cleanly against current htslib.
- Only the tool is built (the gtest-based test binary is skipped).

### Checklist
- [x] `brew install --build-from-source gvcfgenotyper`
- [x] `brew test gvcfgenotyper`
- [x] `brew audit --new --strict gvcfgenotyper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)