### PR TITLE
fix FormulaAudit/CMakeArgs style offenses

### DIFF
--- a/Formula/bamm.rb
+++ b/Formula/bamm.rb
@@ -21,7 +21,7 @@ class Bamm < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make", "install"
     end
     pkgshare.install Dir["examples/*"]

--- a/Formula/bcalm.rb
+++ b/Formula/bcalm.rb
@@ -19,7 +19,7 @@ class Bcalm < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
       bin.install "bcalm"
     end

--- a/Formula/eastr.rb
+++ b/Formula/eastr.rb
@@ -92,7 +92,7 @@ class Eastr < Formula
       end
       inreplace ["src/GSam.h", "src/tmerge.h"], "htslib/htslib", "htslib"
       inreplace "src/vacuum.cpp", "strverscmp", "strcmp"
-      system "cmake", ".", *std_cmake_args
+      system "cmake", "-S", ".", "-B", ".", *std_cmake_args
       system "make"
       bin.install "vacuum", "junction_extractor"
     end

--- a/Formula/epa-ng.rb
+++ b/Formula/epa-ng.rb
@@ -21,7 +21,7 @@ class EpaNg < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
     end
     bin.install "bin/epa-ng"

--- a/Formula/fastq-pair.rb
+++ b/Formula/fastq-pair.rb
@@ -17,7 +17,7 @@ class FastqPair < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/gappa.rb
+++ b/Formula/gappa.rb
@@ -30,7 +30,7 @@ class Gappa < Formula
   def install
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
     end
     bin.install "bin/gappa"

--- a/Formula/hh-suite.rb
+++ b/Formula/hh-suite.rb
@@ -43,7 +43,7 @@ class HhSuite < Formula
     # Fix an error: no member named 'ptr_fun' in namespace 'std'
     inreplace "src/a3m_compress.cpp", "std::not1(std::ptr_fun<int, int>(std::isspace)))",
                                       "[](unsigned char ch) { return !std::isspace(ch); })"
-    system "cmake", ".", *args
+    system "cmake", "-S", ".", "-B", ".", *args
     system "make", "install"
     prefix.install "scripts"
     bin.install_symlink prefix/"scripts/reformat.pl"

--- a/Formula/iqtree.rb
+++ b/Formula/iqtree.rb
@@ -35,7 +35,7 @@ class Iqtree < Formula
     end
 
     mkdir "build" do
-      system "cmake", "..", "-DIQTREE_FLAGS=omp", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", "-DIQTREE_FLAGS=omp", *std_cmake_args
       system "make"
     end
     bin.install "build/iqtree"

--- a/Formula/iqtree2.rb
+++ b/Formula/iqtree2.rb
@@ -28,7 +28,7 @@ class Iqtree2 < Formula
   def install
     mkdir "build" do
       ENV.append_path "PREFIX_PATH", buildpath/"lsd2"
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/libgff.rb
+++ b/Formula/libgff.rb
@@ -17,7 +17,7 @@ class Libgff < Formula
   depends_on "boost"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-S", ".", "-B", ".", *std_cmake_args
     system "make"
     system "make", "install"
   end

--- a/Formula/megahit.rb
+++ b/Formula/megahit.rb
@@ -27,7 +27,7 @@ class Megahit < Formula
   def install
     inreplace "src/megahit", "#!/usr/bin/env python", "#!/usr/bin/env python3"
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/minia.rb
+++ b/Formula/minia.rb
@@ -20,7 +20,7 @@ class Minia < Formula
     mkdir "build" do
       args = std_cmake_args
       args << "-DSKIP_DOC=1"
-      system "cmake", "..", *args
+      system "cmake", "-S", "..", "-B", ".", *args
       system "make"
       system "make", "install"
     end

--- a/Formula/mpboot.rb
+++ b/Formula/mpboot.rb
@@ -27,7 +27,7 @@ class Mpboot < Formula
 
     mkdir "build" do
       simd = build.with?("avx") ? "avx" : "sse4"
-      system "cmake", "..", "-DIQTREE_FLAGS=#{simd}", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", "-DIQTREE_FLAGS=#{simd}", *std_cmake_args
       system "make"
       system "make", "install"
       mv bin/"mpboot-avx", bin/"mpboot" if simd == "avx"

--- a/Formula/nextgenmap.rb
+++ b/Formula/nextgenmap.rb
@@ -14,7 +14,7 @@ class Nextgenmap < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
     end
     bin.install Dir["bin/ngm-#{version}/ngm*"]

--- a/Formula/peat.rb
+++ b/Formula/peat.rb
@@ -22,7 +22,7 @@ class Peat < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
       bin.install "../bin/PEAT"
     end

--- a/Formula/raven-assembler.rb
+++ b/Formula/raven-assembler.rb
@@ -29,7 +29,7 @@ class RavenAssembler < Formula
     args = ["-DRAVEN_BUILD_EXE=ON"]
     args << "-DZLIB_ROOT=#{formula_opt_prefix("zlib-ng-compat")}" if OS.linux?
     mkdir "build" do
-      system "cmake", "..", *args, *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *args, *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/seqan@3.rb
+++ b/Formula/seqan@3.rb
@@ -38,7 +38,7 @@ class SeqanAT3 < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make", "install"
     end
   end

--- a/Formula/sibelia.rb
+++ b/Formula/sibelia.rb
@@ -18,7 +18,7 @@ class Sibelia < Formula
   def install
     # 'build' folder already exists
     mkdir "build" do
-      system "cmake", "../src", *std_cmake_args
+      system "cmake", "-S", "../src", "-B", ".", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/smina.rb
+++ b/Formula/smina.rb
@@ -59,7 +59,7 @@ class Smina < Formula
       EOS
 
       ENV.append "CXXFLAGS", "-DBOOST_TIMER_ENABLE_DEPRECATED=1"
-      system "cmake", "..",
+      system "cmake", "-S", "..", "-B", ".",
              "-DCMAKE_BUILD_TYPE=Release",
              "-DCMAKE_INSTALL_PREFIX=#{prefix}",
              "-DOPENBABEL_DIR=#{formula_opt_prefix("open-babel")}",

--- a/Formula/virulign.rb
+++ b/Formula/virulign.rb
@@ -16,7 +16,7 @@ class Virulign < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "-S", "..", "-B", ".", *std_cmake_args
       system "make"
       system "make", "install"
     end

--- a/Formula/wish.rb
+++ b/Formula/wish.rb
@@ -19,7 +19,7 @@ class Wish < Formula
   fails_with :clang # needs openmp
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-S", ".", "-B", ".", *std_cmake_args
     system "make"
     bin.install "WIsH"
   end


### PR DESCRIPTION
`brew style brewsci/bio` currently fails on `develop`, so every open PR against this tap goes red on `--only-tap-syntax` regardless of what it changes:

```
354 files inspected, 21 offenses detected, 21 offenses autocorrectable
FormulaAudit/CMakeArgs: Use explicit `-S` and `-B` arguments for CMake.
```

This applies `brew style --fix`. All 21 corrections are one-liners and semantics-preserving, because the rule keeps the existing source and build directories rather than relocating them:

```ruby
# inside mkdir "build" do
- system "cmake", "..", *std_cmake_args
+ system "cmake", "-S", "..", "-B", ".", *std_cmake_args

- system "cmake", ".", *std_cmake_args
+ system "cmake", "-S", ".", "-B", ".", *std_cmake_args
```

`brew style .` is clean afterwards (354 files, no offenses). I built and tested one of the touched formulae to confirm nothing moved:

```
brew install --build-from-source brewsci/bio/fastq-pair   # cmake -S .. -B . → ok
brew test brewsci/bio/fastq-pair                          # ok
```

No `revision` bumps, since nothing about the installed output changes.

Worth knowing before merging: because 21 formula files are touched, CI will want to rebuild bottles for all of them, which may surface unrelated pre-existing build failures. Happy to split this per formula, or to reduce it to only the files needed to get `brew style` green, if you would rather.

AI-assisted: the autocorrect run, the verification build and this description were produced with Claude Code and reviewed by me before opening.
